### PR TITLE
Added all simple properties on Site entity #64

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_A_G_Test-0-00000.response
+++ b/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_A_G_Test-0-00000.response
@@ -1,0 +1,9 @@
+--batchresponse_91111b2a-743f-4e03-8684-fe39038e49eb
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+CONTENT-TYPE: application/json;odata=verbose;charset=utf-8
+
+{"d":{"__metadata":{"id":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","uri":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","type":"SP.Site"},"AllowCreateDeclarativeWorkflow":true,"AllowDesigner":true,"AllowExternalEmbeddingWrapper":1,"AllowMasterPageEditing":false,"AllowRevertFromTemplate":false,"AllowSaveDeclarativeWorkflowAsTemplate":true,"AllowSavePublishDeclarativeWorkflow":true,"AllowSelfServiceUpgrade":true,"AllowSelfServiceUpgradeEvaluation":true,"AuditLogTrimmingRetention":90,"CanSyncHubSitePermissions":false,"CanUpgrade":true,"ChannelGroupId":"00000000-0000-0000-0000-000000000000","Classification":"","CommentsOnSitePagesDisabled":false,"CompatibilityLevel":15,"ComplianceAttribute":"","DisableAppViews":false,"DisableCompanyWideSharingLinks":false,"DisableFlows":false,"ExternalSharingTipsEnabled":false,"ExternalUserExpirationInDays":0,"GeoLocation":"EUR","GroupId":"d40f31cc-3876-40f4-bb39-fad5407d9ad4","Id":"e52f882f-72c5-4d16-b0ee-0401cdbd2601"}}
+--batchresponse_91111b2a-743f-4e03-8684-fe39038e49eb--

--- a/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_H_R_Test-0-00000.response
+++ b/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_H_R_Test-0-00000.response
@@ -1,0 +1,9 @@
+--batchresponse_47ff4920-45a0-434c-a68f-dd0debbfc2e2
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+CONTENT-TYPE: application/json;odata=verbose;charset=utf-8
+
+{"d":{"__metadata":{"id":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","uri":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","type":"SP.Site"},"HubSiteId":"00000000-0000-0000-0000-000000000000","Id":"e52f882f-72c5-4d16-b0ee-0401cdbd2601","IsHubSite":false,"LockIssue":null,"MaxItemsPerThrottledOperation":5000,"NeedsB2BUpgrade":false,"PrimaryUri":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup","ReadOnly":false,"RelatedGroupId":"d40f31cc-3876-40f4-bb39-fad5407d9ad4","RequiredDesignerVersion":"15.0.0.0"}}
+--batchresponse_47ff4920-45a0-434c-a68f-dd0debbfc2e2--

--- a/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_S_Z_Test-0-00000.response
+++ b/src/sdk/PnP.Core.Test/SharePoint/MockData/SiteTests/GetSiteSimpleProperties_S_Z_Test-0-00000.response
@@ -1,0 +1,9 @@
+--batchresponse_ca906e43-e4cd-4c2f-aa9a-54e636caf208
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+CONTENT-TYPE: application/json;odata=verbose;charset=utf-8
+
+{"d":{"__metadata":{"id":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","uri":"https://pvxdev.sharepoint.com/sites/pnpcoresdktestgroup/_api/Site","type":"SP.Site"},"Id":"e52f882f-72c5-4d16-b0ee-0401cdbd2601","SensitivityLabelId":null,"SensitivityLabel":"00000000-0000-0000-0000-000000000000","SearchBoxInNavBar":0,"SearchBoxPlaceholderText":null,"ServerRelativeUrl":"/sites/pnpcoresdktestgroup","ShareByEmailEnabled":false,"ShareByLinkEnabled":false,"ShowPeoplePickerSuggestionsForGuestUsers":false,"ShowUrlStructure":false,"SocialBarOnSitePagesDisabled":false,"StatusBarLink":null,"StatusBarText":null,"ThicketSupportDisabled":true,"TrimAuditLog":true,"UIVersionConfigurationEnabled":false,"UpgradeReminderDate":"1899-12-30T00:00:00","UpgradeScheduled":false,"UpgradeScheduledDate":"1753-01-01T00:00:00","Upgrading":false}}
+--batchresponse_ca906e43-e4cd-4c2f-aa9a-54e636caf208--

--- a/src/sdk/PnP.Core.Test/SharePoint/SiteTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/SiteTests.cs
@@ -1,0 +1,171 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PnP.Core.Model.SharePoint;
+using PnP.Core.Test.Utilities;
+using PnP.Core.Utilities;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace PnP.Core.Test.SharePoint
+{
+    [TestClass]
+    public class SiteTests
+    {
+        [ClassInitialize]
+        public static void TestFixtureSetup(TestContext context)
+        {
+            // Configure mocking default for all tests in this class, unless override by a specific test
+            //TestCommon.Instance.Mocking = false;
+        }
+
+        [TestMethod]
+        public async Task GetSiteSimpleProperties_A_G_Test()
+        {
+            //TestCommon.Instance.Mocking = false;
+            using (var context = await TestCommon.Instance.GetContextAsync(TestCommon.TestSite))
+            {
+                ISite site = await context.Site.GetAsync(
+                    p => p.AllowCreateDeclarativeWorkflow,
+                    p => p.AllowDesigner,
+                    p => p.AllowExternalEmbeddingWrapper,
+                    p => p.AllowMasterPageEditing,
+                    p => p.AllowRevertFromTemplate,
+                    p => p.AllowSaveDeclarativeWorkflowAsTemplate,
+                    p => p.AllowSavePublishDeclarativeWorkflow,
+                    p => p.AllowSelfServiceUpgrade,
+                    p => p.AllowSelfServiceUpgradeEvaluation,
+                    p => p.AuditLogTrimmingRetention,
+                    p => p.CanSyncHubSitePermissions,
+                    p => p.CanUpgrade,
+                    p => p.ChannelGroupId,
+                    p => p.Classification,
+                    p => p.CommentsOnSitePagesDisabled,
+                    p => p.CompatibilityLevel,
+                    p => p.ComplianceAttribute,
+                    p => p.DisableAppViews,
+                    p => p.DisableCompanyWideSharingLinks,
+                    p => p.DisableFlows,
+                    p => p.ExternalSharingTipsEnabled,
+                    p => p.ExternalUserExpirationInDays,
+                    p => p.GeoLocation,
+                    p => p.GroupId
+                    );
+
+                Assert.IsNotNull(site);
+                Assert.IsTrue(site.AllowCreateDeclarativeWorkflow);
+                Assert.IsTrue(site.AllowDesigner);
+                Assert.AreNotEqual(0, site.AllowExternalEmbeddingWrapper);
+                Assert.IsFalse(site.AllowMasterPageEditing);
+                Assert.IsFalse(site.AllowRevertFromTemplate);
+                Assert.IsTrue(site.AllowSaveDeclarativeWorkflowAsTemplate);
+                Assert.IsTrue(site.AllowSavePublishDeclarativeWorkflow);
+                Assert.IsTrue(site.AllowSelfServiceUpgrade);
+                Assert.IsTrue(site.AllowSelfServiceUpgradeEvaluation);
+                Assert.AreNotEqual(0, site.AuditLogTrimmingRetention);
+                Assert.IsFalse(site.CanSyncHubSitePermissions);
+                Assert.IsTrue(site.CanUpgrade);
+                Assert.AreEqual(default, site.ChannelGroupId);
+                Assert.AreEqual("", site.Classification);
+                Assert.IsFalse(site.CommentsOnSitePagesDisabled);
+                Assert.AreNotEqual(0, site.CompatibilityLevel);
+                Assert.AreEqual("", site.ComplianceAttribute);
+                Assert.IsFalse(site.DisableAppViews);
+                Assert.IsFalse(site.DisableCompanyWideSharingLinks);
+                Assert.IsFalse(site.DisableFlows);
+                Assert.IsFalse(site.ExternalSharingTipsEnabled);
+                Assert.AreEqual(0, site.ExternalUserExpirationInDays);
+                Assert.AreNotEqual("", site.GeoLocation);
+                Assert.AreNotEqual(default, site.GroupId);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetSiteSimpleProperties_H_R_Test()
+        {
+            //TestCommon.Instance.Mocking = false;
+            using (var context = await TestCommon.Instance.GetContextAsync(TestCommon.TestSite))
+            {
+                ISite site = await context.Site.GetAsync(
+                    p => p.HubSiteId,
+                    p => p.IsHubSite,
+                    p => p.LockIssue,
+                    p => p.MaxItemsPerThrottledOperation,
+                    p => p.NeedsB2BUpgrade,
+                    p => p.PrimaryUri,
+                    p => p.ReadOnly,
+                    p => p.RelatedGroupId,
+                    p => p.RequiredDesignerVersion
+                    );
+
+                Assert.IsNotNull(site);
+                Assert.AreEqual(default, site.HubSiteId);
+                Assert.IsFalse(site.IsHubSite);
+                Assert.IsNull(site.LockIssue);
+                Assert.AreNotEqual(0, site.MaxItemsPerThrottledOperation);
+                Assert.IsFalse(site.NeedsB2BUpgrade);
+                Assert.IsNotNull(site.PrimaryUri);
+                Assert.AreNotEqual("", site.PrimaryUri?.ToString());
+                Assert.IsFalse(site.ReadOnly);
+                Assert.AreNotEqual(default, site.RelatedGroupId);
+                Assert.AreNotEqual("", site.RequiredDesignerVersion);
+            }
+        }
+
+        [TestMethod]
+        public async Task GetSiteSimpleProperties_S_Z_Test()
+        {
+            //TestCommon.Instance.Mocking = false;
+            using (var context = await TestCommon.Instance.GetContextAsync(TestCommon.TestSite))
+            {
+                ISite site = await context.Site.GetAsync(
+                    p => p.SearchBoxInNavBar,
+                    p => p.SearchBoxPlaceholderText,
+                    p => p.SearchCenterUrl,
+                    p => p.SensitivityLabelId,
+                    p => p.SensitivityLabel,
+                    p => p.ServerRelativeUrl,
+                    p => p.ShareByEmailEnabled,
+                    p => p.ShareByLinkEnabled,
+                    p => p.ShowPeoplePickerSuggestionsForGuestUsers,
+                    p => p.ShowUrlStructure,
+                    p => p.SocialBarOnSitePagesDisabled,
+                    p => p.StatusBarLink,
+                    p => p.StatusBarText,
+                    p => p.ThicketSupportDisabled,
+                    p => p.TrimAuditLog,
+                    p => p.UIVersionConfigurationEnabled,
+                    p => p.UpgradeReminderDate,
+                    p => p.UpgradeScheduled,
+                    p => p.UpgradeScheduledDate,
+                    p => p.Upgrading
+                    );
+
+                Assert.IsNotNull(site);
+                Assert.AreEqual(SearchBoxInNavBar.Inherit, site.SearchBoxInNavBar);
+                Assert.IsNull(site.SearchBoxPlaceholderText);
+                // TODO This one is not loaded => Review why Graph is not called
+                //Assert.IsNull(site.SearchCenterUrl);
+                Assert.IsNull(site.SensitivityLabelId);
+                Assert.AreEqual(default, site.SensitivityLabel);
+                Assert.AreNotEqual("", site.ServerRelativeUrl);
+                Assert.IsFalse(site.ShareByEmailEnabled);
+                Assert.IsFalse(site.ShareByLinkEnabled);
+                Assert.IsFalse(site.ShowPeoplePickerSuggestionsForGuestUsers);
+                Assert.IsFalse(site.ShowUrlStructure);
+                Assert.IsFalse(site.SocialBarOnSitePagesDisabled);
+                Assert.IsNull(site.StatusBarLink);
+                Assert.IsNull(site.StatusBarText);
+                Assert.IsTrue(site.ThicketSupportDisabled);
+                Assert.IsTrue(site.TrimAuditLog);
+                Assert.IsFalse(site.UIVersionConfigurationEnabled);
+                Assert.AreEqual(1899, site.UpgradeReminderDate.Year);
+                Assert.IsFalse(site.UpgradeScheduled);
+                Assert.AreEqual(1753, site.UpgradeScheduledDate.Year);
+                Assert.IsFalse(site.Upgrading);
+                // TODO This one is not loaded => Review why Graph is not called
+                //Assert.IsNotNull(site.Url);
+                //Assert.AreNotEqual("", site.Url.ToString());
+            }
+        }
+
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Site.gen.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Site.gen.cs
@@ -83,6 +83,106 @@ namespace PnP.Core.Model.SharePoint
         /* Not directly a field in the Site object*/
         public string SearchCenterUrl { get => GetValue<string>(); set => SetValue(value); }
 
+
+
+        // ==================== TO TEST ==================================
+
+        public bool AllowCreateDeclarativeWorkflow { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowDesigner { get => GetValue<bool>(); set => SetValue(value); }
+
+        public int AllowExternalEmbeddingWrapper { get => GetValue<int>(); set => SetValue(value); }
+
+        public bool AllowMasterPageEditing { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowRevertFromTemplate { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowSaveDeclarativeWorkflowAsTemplate { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowSavePublishDeclarativeWorkflow { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowSelfServiceUpgrade { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool AllowSelfServiceUpgradeEvaluation { get => GetValue<bool>(); set => SetValue(value); }
+
+        public int AuditLogTrimmingRetention { get => GetValue<int>(); set => SetValue(value); }
+
+        public bool CanSyncHubSitePermissions { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool CanUpgrade { get => GetValue<bool>(); set => SetValue(value); }
+
+        public Guid ChannelGroupId { get => GetValue<Guid>(); set => SetValue(value); }
+
+        public bool CommentsOnSitePagesDisabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public int CompatibilityLevel { get => GetValue<int>(); set => SetValue(value); }
+
+        public string ComplianceAttribute { get => GetValue<string>(); set => SetValue(value); }
+
+        public bool DisableAppViews { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool DisableCompanyWideSharingLinks { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool DisableFlows { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool ExternalSharingTipsEnabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public int ExternalUserExpirationInDays { get => GetValue<int>(); set => SetValue(value); }
+
+        public string GeoLocation { get => GetValue<string>(); set => SetValue(value); }
+
+        public Guid HubSiteId { get => GetValue<Guid>(); set => SetValue(value); }
+
+        public bool IsHubSite { get => GetValue<bool>(); set => SetValue(value); }
+
+        public string LockIssue { get => GetValue<string>(); set => SetValue(value); }
+
+        public int MaxItemsPerThrottledOperation { get => GetValue<int>(); set => SetValue(value); }
+
+        public bool NeedsB2BUpgrade { get => GetValue<bool>(); set => SetValue(value); }
+
+        public Uri PrimaryUri { get => GetValue<Uri>(); set => SetValue(value); }
+
+        public bool ReadOnly { get => GetValue<bool>(); set => SetValue(value); }
+
+        public Guid RelatedGroupId { get => GetValue<Guid>(); set => SetValue(value); }
+
+        public string RequiredDesignerVersion { get => GetValue<string>(); set => SetValue(value); }
+
+        public string SearchBoxPlaceholderText { get => GetValue<string>(); set => SetValue(value); }
+
+        public string SensitivityLabelId { get => GetValue<string>(); set => SetValue(value); }
+
+        public Guid SensitivityLabel { get => GetValue<Guid>(); set => SetValue(value); }
+
+        public string ServerRelativeUrl { get => GetValue<string>(); set => SetValue(value); }
+
+        public bool ShareByEmailEnabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool ShareByLinkEnabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool ShowPeoplePickerSuggestionsForGuestUsers { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool ShowUrlStructure { get => GetValue<bool>(); set => SetValue(value); }
+
+        public string StatusBarLink { get => GetValue<string>(); set => SetValue(value); }
+
+        public string StatusBarText { get => GetValue<string>(); set => SetValue(value); }
+
+        public bool ThicketSupportDisabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool TrimAuditLog { get => GetValue<bool>(); set => SetValue(value); }
+
+        public bool UIVersionConfigurationEnabled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public DateTime UpgradeReminderDate { get => GetValue<DateTime>(); set => SetValue(value); }
+
+        public bool UpgradeScheduled { get => GetValue<bool>(); set => SetValue(value); }
+
+        public DateTime UpgradeScheduledDate { get => GetValue<DateTime>(); set => SetValue(value); }
+
+        public bool Upgrading { get => GetValue<bool>(); set => SetValue(value); }
+
         [KeyProperty("Id")]
         public override object Key { get => this.Id; set => this.Id = Guid.Parse(value.ToString()); }
     }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/ISite.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/ISite.cs
@@ -42,6 +42,7 @@ namespace PnP.Core.Model.SharePoint
         /// Defines the Search Center URL
         /// </summary>
         public string SearchCenterUrl { get; set; }
+
         /// <summary>
         /// The RootWeb of the Site object
         /// </summary>
@@ -56,5 +57,303 @@ namespace PnP.Core.Model.SharePoint
         /// Collection of features enabled for the site
         /// </summary>
         public IFeatureCollection Features { get; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the creation of declarative workflows is allowed on this site collection.
+        /// </summary>
+        public bool AllowCreateDeclarativeWorkflow { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether a designer can be used on this site collection.
+        /// </summary>
+        public bool AllowDesigner { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether external embedding wrapper is allowed on this site collection.
+        /// </summary>
+        public int AllowExternalEmbeddingWrapper { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether master page editing is allowed on this site collection.
+        /// </summary>
+        public bool AllowMasterPageEditing { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether this site collection can be reverted to its base template.
+        /// </summary>
+        public bool AllowRevertFromTemplate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether it is allowed to save declarative workflows as template on this site collection.
+        /// </summary>
+        public bool AllowSaveDeclarativeWorkflowAsTemplate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether it is allowed to save and publish declarative workflows on this site collection.
+        /// </summary>
+        public bool AllowSavePublishDeclarativeWorkflow { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether version to version upgrade is allowed on this site collection.
+        /// </summary>
+        public bool AllowSelfServiceUpgrade { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether upgrade evaluation site collection is allowed on this site collection.
+        /// </summary>
+        public bool AllowSelfServiceUpgradeEvaluation { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the audit log trimming retention on this site.
+        /// </summary>
+        public int AuditLogTrimmingRetention { get; set; }
+
+        // TODO: Review if readonly
+        // TODO: Review this property docs
+        /// <summary>
+        /// Gets a value that specifies whether the site collections has permissions to sync to hub site.
+        /// </summary>
+        public bool CanSyncHubSitePermissions { get; }
+
+        /// <summary>
+        /// Property indicating whether or not this object can be upgraded.
+        /// </summary>
+        public bool CanUpgrade { get; }
+
+        // TODO: Review if readonly
+        // TODO: Review this property docs
+        /// <summary>
+        /// Gets the Id of the channel group.
+        /// </summary>
+        public Guid ChannelGroupId { get; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the comments on site pages are disabled on this site collection.
+        /// </summary>
+        public bool CommentsOnSitePagesDisabled { get; set; }
+
+        /// <summary>
+        /// Gets the major version of this site collection for purposes of major version-level compatibility checks.
+        /// </summary>
+        public int CompatibilityLevel { get; }
+
+        /// <summary>
+        /// Gets or sets the compliance attribute of this site collection.
+        /// </summary>
+        public string ComplianceAttribute { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the app views are disabled on this site collection.
+        /// </summary>
+        public bool DisableAppViews { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the company-wide sharing links are disabled on this site collection.
+        /// </summary>
+        public bool DisableCompanyWideSharingLinks { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether Flows are disabled on this site collection.
+        /// </summary>
+        public bool DisableFlows { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates whether external sharing tips are enabled.
+        /// </summary>
+        public bool ExternalSharingTipsEnabled { get; }
+
+        // TODO: Review if readonly
+        /// <summary>
+        /// Gets or sets the expiration in days for external users on this site collection.
+        /// </summary>
+        public int ExternalUserExpirationInDays { get; set; }
+
+        /// <summary>
+        /// Gets the geolocation of this site collection.
+        /// </summary>
+        public string GeoLocation { get; }
+
+        /// <summary>
+        /// Gets the Id of the Hub Site this site collection is connected to.
+        /// </summary>
+        public Guid HubSiteId { get; }
+
+        // TODO: Review if readonly
+        /// <summary>
+        /// Gets or sets the Id (as String) of the sensitivity label of this site collection.
+        /// </summary>
+        public string SensitivityLabelId { get; set; }
+
+        // TODO: Review this property docs
+        // TODO: Review if readonly
+        /// <summary>
+        /// Gets or sets the Id (as Guid) of the sensitivity label of this site collection
+        /// </summary>
+        public Guid SensitivityLabel { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates whether this site collection is a Hub Site.
+        /// </summary>
+        public bool IsHubSite { get; }
+
+        /// <summary>
+        /// Gets or sets the comment that is used in locking a site collection.
+        /// </summary>
+        public string LockIssue { get; set; }
+
+        /// <summary>
+        /// Gets a value that specifies the maximum number of list items allowed per operation before throttling will occur.
+        /// </summary>
+        public int MaxItemsPerThrottledOperation { get; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether this site collection needs a B2B upgrade.
+        /// </summary>
+        public bool NeedsB2BUpgrade { get; set; }
+
+        /// <summary>
+        /// Specifies the primary URI of this site collection, including the host name, port number, and path.
+        /// </summary>
+        public Uri PrimaryUri { get; }
+
+        /// <summary>
+        /// Gets or sets a Boolean value that specifies whether the site collection is read-only, locked, and unavailable for write access.
+        /// </summary>
+#pragma warning disable CA1716 // Identifiers should not match keywords
+        public bool ReadOnly { get; set; }
+#pragma warning restore CA1716 // Identifiers should not match keywords
+
+        /// <summary>
+        /// Gets the Id of the group related to this site collection.
+        /// </summary>
+        public Guid RelatedGroupId { get; }
+
+        /// <summary>
+        /// Gets a value that indicates the required Designer version for this site collection.
+        /// </summary>
+        public string RequiredDesignerVersion { get; }
+
+        // TODO Probably not expecting this to be implemented, to decide whether include it or not
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public int SandboxedCodeActivationCapability { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies the placeholder text of this site collection search box.
+        /// </summary>
+        public string SearchBoxPlaceholderText { get; set; }
+
+        /// <summary>
+        /// Gets the server-relative URL of the root Web site in the site collection.
+        /// </summary>
+        public string ServerRelativeUrl { get; }
+
+        // TODO: Review if readonly
+        /// <summary>
+        /// Gets or sets a value that specifies whether sharing by e-mail is enabled on this site collection.
+        /// </summary>
+        public bool ShareByEmailEnabled { get; set; }
+
+        /// <summary>
+        /// Property that indicates whether users will be able to share links to documents that can be accessed without logging in.
+        /// </summary>
+        public bool ShareByLinkEnabled { get;  }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether guest users should be displayed as suggestions in people picker on this site collection.
+        /// </summary>
+        public bool ShowPeoplePickerSuggestionsForGuestUsers { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the URL structure of this site collection is viewable.
+        /// </summary>
+        public bool ShowUrlStructure { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies the status bar link on this site collection.
+        /// </summary>
+        public string StatusBarLink { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies the text of the status bar on this site collection.
+        /// </summary>
+        public string StatusBarText { get; set; }
+
+        // TODO: Review this property docs (No clue what thicket support is)
+        /// <summary>
+        /// Gets a value that indicates whether thicket support is disabled on this site collection.
+        /// </summary>
+        public bool ThicketSupportDisabled { get;  }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether audit log is trimmed.
+        /// </summary>
+        public bool TrimAuditLog { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies whether the Visual Upgrade UI of this site collection is displayed.
+        /// </summary>
+        public bool UIVersionConfigurationEnabled { get; set; }
+
+        /// <summary>
+        /// Specifies a date, after which site collection administrators will be reminded to upgrade the site collection.
+        /// </summary>
+        public DateTime UpgradeReminderDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies if upgrade is scheduled on this site collection.
+        /// </summary>
+        public bool UpgradeScheduled { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value that specifies the scheduled date of this site colleection upgrage.
+        /// </summary>
+        public DateTime UpgradeScheduledDate { get; set; }
+
+        /// <summary>
+        /// Gets a value that indicates whether the site is currently upgrading.
+        /// </summary>
+        public bool Upgrading { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IAudit Audit { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IScriptSafeDomainCollection CustomScriptSafeDomains { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IEventReceiverDefinitionCollection EventReceivers { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IGroup HubSiteSynchronizableVisitorGroup { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IUser Owner { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IRecycleBinItemCollection RecycleBin { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IUser SecondaryContact { get; }
+
+        ///// <summary>
+        ///// To update...
+        ///// </summary>
+        //public IUserCustomActionCollection UserCustomActions { get; }
     }
 }


### PR DESCRIPTION
This one adds test to cover all properties of the Site entity.
It pointed out that some properties are not loaded (probably since Graph is not called)
linked to #64 