### PR TITLE
Fixed a minor bug in auth test where scope was missing

### DIFF
--- a/src/sdk/PnP.Core.Test/Base/AuthenticationTests.cs
+++ b/src/sdk/PnP.Core.Test/Base/AuthenticationTests.cs
@@ -46,7 +46,7 @@ namespace PnP.Core.Test.Base
             using (var context = await TestCommon.Instance.GetContextAsync(TestCommon.TestSite))
             {
                 var accessToken = await context.AuthenticationProvider.GetAccessTokenAsync(
-                    context.Uri, null).ConfigureAwait(true);
+                    context.Uri, new string[] { "AllSites.FullControl" }).ConfigureAwait(true);
 
                 Assert.IsNotNull(accessToken);
             }


### PR DESCRIPTION
This scope wasn't defined thus test would fail.
The UserNamePasswordAuthenticationProvider requires this param to be not null