### PR TITLE
Fixed project references for Az Function demo

### DIFF
--- a/samples/Demo.AzureFunction/Demo.AzureFunction.csproj
+++ b/samples/Demo.AzureFunction/Demo.AzureFunction.csproj
@@ -8,12 +8,12 @@
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.15.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.18.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.21.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\sdk\PnP.Core.Auth\PnP.Core.Auth.csproj" />
-    <ProjectReference Include="..\..\sdk\PnP.Core\PnP.Core.csproj" />
+    <ProjectReference Include="..\..\src\sdk\PnP.Core.Auth\PnP.Core.Auth.csproj" />
+    <ProjectReference Include="..\..\src\sdk\PnP.Core\PnP.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/samples/Demo.AzureFunction/Demo.AzureFunction.sln
+++ b/samples/Demo.AzureFunction/Demo.AzureFunction.sln
@@ -5,9 +5,9 @@ VisualStudioVersion = 16.0.30503.244
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Demo.AzureFunction", "Demo.AzureFunction.csproj", "{0B0B9B53-92D8-4623-A273-D26C85C7C360}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PnP.Core", "..\..\sdk\PnP.Core\PnP.Core.csproj", "{58616637-9AC1-40A4-9F98-4D0E96167176}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PnP.Core", "..\..\src\sdk\PnP.Core\PnP.Core.csproj", "{58616637-9AC1-40A4-9F98-4D0E96167176}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PnP.Core.Auth", "..\..\sdk\PnP.Core.Auth\PnP.Core.Auth.csproj", "{1F0A3444-829F-4F4B-8B87-EECB2F16A9B2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PnP.Core.Auth", "..\..\src\sdk\PnP.Core.Auth\PnP.Core.Auth.csproj", "{1F0A3444-829F-4F4B-8B87-EECB2F16A9B2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Project references were broken for the Azure Functions demo. They were restored to point to the right projects. Also updated dependency `Microsoft.Identity.Client` to version `4.21` to match PnP.Core.