### PR TITLE
Fix for older SharePoint UI created image web parts where links is se…

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -388,9 +388,12 @@ namespace PnP.Core.Model.SharePoint
 
                 if (ServerProcessedContent.TryGetProperty("links", out JsonElement links))
                 {
-                    foreach (var property in links.EnumerateObject())
+                    if (links.ValueKind != JsonValueKind.Null)
                     {
-                        htmlWriter.Append($@"<a data-sp-prop-name=""{property.Name}"" href=""{property.Value.GetString()}""></a>");
+                        foreach (var property in links.EnumerateObject())
+                        {
+                            htmlWriter.Append($@"<a data-sp-prop-name=""{property.Name}"" href=""{property.Value.GetString()}""></a>");
+                        }
                     }
                 }
 


### PR DESCRIPTION
…t to null

PnP fails to apply template when client side page image web part's _serverProcessedContent/links_ is equal to null. dataVersion is 1.2 and was created May 2020.

![image](https://user-images.githubusercontent.com/14074790/110670296-3be96e80-819b-11eb-9992-4f3aa851fbff.png)

Null value causes applying template to fail.

> Error Inner Message >
The requested operation requires an element of type 'Object', but the target element has type 'Null'.
Error Inner StackTrace >
+59.910s   at System.Text.Json.JsonElement.EnumerateObject()
   at PnP.Core.Model.SharePoint.PageWebPart.RenderHtmlProperties(StringBuilder& htmlWriter)
   at PnP.Core.Model.SharePoint.PageWebPart.ToHtml(Single controlIndex)
   at PnP.Core.Model.SharePoint.CanvasColumn.ToHtml()
   at PnP.Core.Model.SharePoint.CanvasSection.ToHtml()
   at PnP.Core.Model.SharePoint.Page.ToHtml()
   at PnP.Core.Model.SharePoint.Page.<SaveAsync>d__128.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at PnP.Core.Model.SharePoint.Page.Save(String pageName)
   at PnP.Framework.Provisioning.ObjectHandlers.ObjectClientSidePages.CreatePage(Web web, ProvisioningTemplate template, TokenParser parser, PnPMonitoredScope scope, BaseClientSidePage clientSidePage, String pagesLibrary, List pagesLibraryList, Int32& currentPageIndex, List`1 preCreatedPages)
   at PnP.Framework.Provisioning.ObjectHandlers.ObjectClientSidePages.ProvisionObjects(Web web, ProvisioningTemplate template, TokenParser parser, ProvisioningTemplateApplyingInformation applyingInformation)
   at PnP.Framework.Provisioning.ObjectHandlers.SiteToTemplateConversion.ApplyRemoteTemplate(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation provisioningInfo, Boolean calledFromHierarchy, TokenParser tokenParser)
   at Microsoft.SharePoint.Client.WebExtensions.ApplyProvisioningTemplate(Web web, ProvisioningTemplate template, ProvisioningTemplateApplyingInformation applyingInformation)