### PR TITLE
Bug - remove page name normalization

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1439,8 +1439,6 @@ namespace PnP.Core.Model.SharePoint
                 }
             }
 
-            pageName = NormalizePageName(pageName);
-
             // Validate we're not using "wrong" layouts for the given site type
             await ValidateOneColumnFullWidthSectionUsageAsync().ConfigureAwait(false);
 
@@ -1792,17 +1790,6 @@ namespace PnP.Core.Model.SharePoint
             }
 
             return new Tuple<string, string>(folderName, pageNameWithoutFolder);
-        }
-
-        private static string NormalizePageName(string pageName)
-        {
-            if (string.IsNullOrEmpty(pageName))
-            {
-                return pageName;
-            }
-
-            // if a page name contains spaces then let's replace them with dashes, just like the UI does
-            return pageName.Replace(" ", "-").Replace("#", "-");
         }
 
         private async Task ValidateOneColumnFullWidthSectionUsageAsync()


### PR DESCRIPTION
This page name normalization is not correct. We should not assume that all pages with spaces in their name should be renamed. This causes issue between Core and Framework too where Framework has no normalization and when it tries to load the file/list item or verify the page is created, it queries for the page with spaces. The save method in Core always saves with replacing spaces with dashes.

This also causes issues with links to pages throughout a template that have linked to the page with spaces in its name.

I believe this normalization was implemented without understanding the implications. I feel that if SharePoint allows a user to rename a page to have spaces in the file name - then PnP should respect this and not rename the file.

@jansenbe I'm curious to know your take on this?