### PR TITLE
Update IList.cs

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IList.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IList.cs
@@ -46,7 +46,7 @@ namespace PnP.Core.Model.SharePoint
         public ListTemplateType TemplateType { get; }
 
         /// <summary>
-        /// Gets or sets a value that specifies whether the new list is displayed on the Quick Launch of the site.
+        /// Gets the value of list absolute URL
         /// </summary>
         public string Url { get; }
 


### PR DESCRIPTION
Incorrect description of URL property. Guess it contains absolute URL?
Tried to get URL to really see what it has, but for some reason, I just couldn't get that property to load.