### PR TITLE
fix BannerImageUrl to use sphost only since siteid, webid are given as parameter

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1748,7 +1748,7 @@ namespace PnP.Core.Model.SharePoint
                         await PnPContext.Site.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
                         await PnPContext.Web.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
 
-                        SetBannerImageUrlField($"{PnPContext.Uri}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}");
+                        SetBannerImageUrlField($"{PnPContext.Uri.Scheme}://{PnPContext.Uri.DnsSafeHost}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}");
                     }
                 }
             }


### PR DESCRIPTION
Fix BannerImageUrl to use sphost only since siteid, webid are given as parameters.

First i did want to fix on Extract in pnpframework, but since ServerRelativeImageUrl is referred to at some many places i came back here to fix it on provision. 

The Property in PnP-XML on ClientSidePage->Header would look like this.
 ServerRelativeImageUrl="{site}/SiteAssets/SitePages/testedtec-Neuigkeitenvorlage/33700-20931-Startseite_testedtec365.jpg"
will be set like this:
$"{PnPContext.Uri.Scheme}://{PnPContext.Uri.DnsSafeHost}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}"
