### PR TITLE
Enhance apirequest to allow setting http-header

### DIFF
--- a/src/sdk/PnP.Core/Model/Base/BaseDataModel.cs
+++ b/src/sdk/PnP.Core/Model/Base/BaseDataModel.cs
@@ -211,7 +211,8 @@ namespace PnP.Core.Model
                                                                 {
                                                                     ExecuteRequestApiCall = true,
                                                                     SkipCollectionClearing = true,
-                                                                    RawRequest = true
+                                                                    RawRequest = true, 
+                                                                    Headers= request.Headers
                                                                 }
                                                     , request.HttpMethod).ConfigureAwait(false);
 

--- a/src/sdk/PnP.Core/Services/Core/ApiCall.cs
+++ b/src/sdk/PnP.Core/Services/Core/ApiCall.cs
@@ -9,7 +9,7 @@ namespace PnP.Core.Services
     /// </summary>
     internal struct ApiCall
     {
-        internal ApiCall(string request, ApiType apiType, string jsonBody = null, string receivingProperty = null, bool loadPages = false)
+        internal ApiCall(string request, ApiType apiType, string jsonBody = null, string receivingProperty = null, bool loadPages = false, Dictionary<string, string> headers = null)
         {
             Type = apiType;
             Request = request;
@@ -29,9 +29,10 @@ namespace PnP.Core.Services
             LoadPages = loadPages;
             SkipCollectionClearing = false;
             ExecuteRequestApiCall = false;
+            Headers = headers;
         }
 
-        internal ApiCall(List<Core.CSOM.Requests.IRequest<object>> csomRequests, string receivingProperty = null)
+        internal ApiCall(List<Core.CSOM.Requests.IRequest<object>> csomRequests, string receivingProperty = null, Dictionary<string, string> headers=null)
         {
             Request = null;
             Type = ApiType.CSOM;
@@ -51,6 +52,7 @@ namespace PnP.Core.Services
             LoadPages = false;
             SkipCollectionClearing = false;
             ExecuteRequestApiCall = false;
+            Headers = headers;
         }
 
         /// <summary>
@@ -146,5 +148,10 @@ namespace PnP.Core.Services
         /// Flag that indicates this ApiCall was issued from an ExecuteRequest method
         /// </summary>
         internal bool ExecuteRequestApiCall { get; set; }
+
+        /// <summary>
+        /// Http-Headers for Request
+        /// </summary>
+        internal Dictionary<string, string> Headers { get; set; } 
     }
 }

--- a/src/sdk/PnP.Core/Services/Core/ApiRequest.cs
+++ b/src/sdk/PnP.Core/Services/Core/ApiRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http;
+﻿using System.Collections.Generic;
+using System.Net.Http;
 
 namespace PnP.Core.Services
 {
@@ -15,12 +16,14 @@ namespace PnP.Core.Services
         /// <param name="type"><see cref="ApiRequestType"/> of the request</param>
         /// <param name="request">Actual API call to issue</param>
         /// <param name="body">Optional body of the request</param>
-        public ApiRequest(HttpMethod httpMethod, ApiRequestType type, string request, string body)
+        /// <param name="headers">Optional for the request</param>
+        public ApiRequest(HttpMethod httpMethod, ApiRequestType type, string request, string body, Dictionary<string,string>headers=null)
         {
             HttpMethod = httpMethod;
             Type = type;
             Request = request;
             Body = body;
+            Headers = headers;
         }
 
         /// <summary>
@@ -51,5 +54,10 @@ namespace PnP.Core.Services
         /// The optional payload/body of the API call to execute
         /// </summary>
         public string Body { get; set; }
+
+        /// <summary>
+        /// The optional headers of the API call to execute - for example IF-Match for PATCH Request
+        /// </summary>
+        public Dictionary<string, string> Headers { get; }
     }
 }

--- a/src/sdk/PnP.Core/Services/Core/BatchClient.cs
+++ b/src/sdk/PnP.Core/Services/Core/BatchClient.cs
@@ -771,6 +771,21 @@ namespace PnP.Core.Services
                     };
                     };
 
+                    if(request.ApiCall.Headers!=null)
+                    {
+                        foreach(var key in request.ApiCall.Headers.Keys)
+                        {
+                            if(!graphRequest.Headers.ContainsKey(key))
+                            {
+                                graphRequest.Headers.Add(key, request.ApiCall.Headers[key]);
+                            }
+                            else
+                            {
+                                graphRequest.Headers[key] = request.ApiCall.Headers[key];
+                            }
+                        }
+                    }
+
                     graphRequests.Requests.Add(graphRequest);
 
 #if DEBUG

--- a/src/sdk/PnP.Core/Services/Core/BatchClient.cs
+++ b/src/sdk/PnP.Core/Services/Core/BatchClient.cs
@@ -775,13 +775,14 @@ namespace PnP.Core.Services
                     {
                         foreach(var key in request.ApiCall.Headers.Keys)
                         {
-                            if(!graphRequest.Headers.ContainsKey(key))
+                            string existingKey = graphRequest.Headers.Keys.FirstOrDefault(k => k.Equals(key, StringComparison.InvariantCultureIgnoreCase));
+                            if (string.IsNullOrWhiteSpace(existingKey))
                             {
                                 graphRequest.Headers.Add(key, request.ApiCall.Headers[key]);
                             }
                             else
                             {
-                                graphRequest.Headers[key] = request.ApiCall.Headers[key];
+                                graphRequest.Headers[existingKey] = request.ApiCall.Headers[key];
                             }
                         }
                     }


### PR DESCRIPTION
In order to do a Graph PATCH Request i needed the ability to pass in the IF-MATCH Header with the etag.
The enhancement allows this by adding a optional Dictionary to APIRequest and APICall which then will be respected in BuildMicrosoftGraphBatchRequestContent.

I did not change BuildSharePointRestBatchRequestContent as I could not see the benefit of doing so and 
the IF-MATCH=* in SP-REST has already the todo flag set and will be quite a large change if etag should be respected by default.