### PR TITLE
Fix for ChunkedFileUpload

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FileCollection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FileCollection.cs
@@ -134,11 +134,14 @@ namespace PnP.Core.Model.SharePoint
                 }
                 else
                 {
+                    var chunkBuffer = new byte[bytesRead];
+                    Array.Copy(buffer, chunkBuffer, chunkBuffer.Length);
+
                     var endpointUrl = $"_api/web/getFileById('{{Id}}')/continueupload(uploadId=guid'{uploadId}',fileOffset={offset})";
                     var api = new ApiCall(endpointUrl, ApiType.SPORest)
                     {
                         Interactive = true,
-                        BinaryBody = buffer
+                        BinaryBody = chunkBuffer
                     };
                     await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
                 }


### PR DESCRIPTION
The `AddAsync` method of the `FileCollection` calls the `ChunkedFileUpload` method internally when a file is larger than 10mb. This works great in nearly every situation.

However, I recently ran into an issue when executing this code from within an Azure Function with a `BlobTrigger`. Here is the method being used:

```
public async Task UploadDocumentFromBlob(string siteUrl, string folderServerRelativeUrl, string docName, Stream blob, IAuthenticationProvider spAuthProvider) {
    using (var pnpContext = await _pnpContextFactory.CreateAsync(new System.Uri(siteUrl), spAuthProvider))
    {
        var folder = await pnpContext.Web.GetFolderByServerRelativeUrlAsync(folderServerRelativeUrl);
        await folder.Files.AddAsync(docName, blob, true);
    }
}
```

The above worked without issue for files smaller than 10mb but ran into an issue nearly every time with files larger than 10mb.

The issue is with how the stream is being read. It is read into a buffer with a length of 10mb as part of the while loop. The first upload and the final upload work. The first upload works because no offset is required since it's always zero. The final upload works because the finalBuffer is used (only containing the remaining bytes). 

However, the continueupload calls had the possibility of failing because the entire buffer was used assuming the stream always returned the buffer size (10mb) unless it was the end of the stream. The problem can be found in the [Stream.Read documentation](https://docs.microsoft.com/en-us/dotnet/api/system.io.stream.read?view=net-5.0&viewFallbackFrom=net-3.1#System_IO_Stream_Read_System_Byte___System_Int32_System_Int32_) where it says of the return value:

>The total number of bytes read into the buffer. This can be less than the number of bytes requested if that many bytes are not currently available, or zero (0) if the end of the stream has been reached.

The stream coming from the Azure Blob is apparently a bit slow. The Read wasn't always returning the full buffer size, but the code assumed it. This was causing the full buffer to be sent to the continueupload point. The offset was, however, being calculated correctly. This was causing "Upload was incomplete" errors from SharePoint.

The fix is to utilize the `bytesRead` to copy whatever was actually received (even when less than the intended buffer length) to create a `chunk`. This chunk is used instead of the buffer in the `BinaryBody` parameter. Doing this ensures that the `ChunkedFileUpload` works when the stream is fast (like a FileStream) and when a bit slower (like a Blob Stream).