### PR TITLE
Fixed an issue where adding items to the root site collection resulted in a 404

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
@@ -86,7 +86,6 @@ namespace PnP.Core.Model.SharePoint
             };
             AddApiCallHandler = async (keyValuePairs) =>
             {
-
                 var parentList = Parent.Parent as List;
                 // sample parent list uri: https://bertonline.sharepoint.com/sites/modern/_api/Web/Lists(guid'b2d52a36-52f1-48a4-b499-629063c6a38c')
                 var parentListUri = parentList.GetMetadata(PnPConstants.MetaDataUri);
@@ -99,7 +98,7 @@ namespace PnP.Core.Model.SharePoint
                 string serverRelativeUrl = null;
                 if (string.IsNullOrEmpty(parentListTitle) || string.IsNullOrEmpty(parentListUri) || !parentList.IsPropertyAvailable(p => p.TemplateType))
                 {
-                    // Fall back to loading the rootfolder propery if we can't determine the list name
+                    // Fall back to loading the RootFolder property if we can't determine the list name
                     await parentList.EnsurePropertiesAsync(p => p.RootFolder).ConfigureAwait(false);
                     serverRelativeUrl = parentList.RootFolder.ServerRelativeUrl;
                 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListMetaDataMapper.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListMetaDataMapper.cs
@@ -5,7 +5,6 @@ namespace PnP.Core.Model.SharePoint
 {
     internal static class ListMetaDataMapper
     {
-
         internal static string MicrosoftGraphNameToRestEntityTypeName(string microsoftGraphListName, ListTemplateType listTemplateType)
         {
             if (listTemplateType == ListTemplateType.UserInformation)
@@ -23,7 +22,7 @@ namespace PnP.Core.Model.SharePoint
             }
             
             // Build the name
-            string entityNameToUse = $"{entityName.ToString().Replace(" ", "")}{(isList ? "List" : "")}";
+            string entityNameToUse = $"{entityName.Replace(" ", "")}{(isList ? "List" : "")}";
             // Ensure first character is upper case
             entityNameToUse = entityNameToUse.First().ToString().ToUpper() + entityNameToUse.Substring(1);
 
@@ -32,6 +31,7 @@ namespace PnP.Core.Model.SharePoint
 
         internal static string RestEntityTypeNameToUrl(Uri pnpContextUri, string restEntityTypeName, ListTemplateType listTemplateType)
         {
+            var contextUrl = pnpContextUri.ToString().TrimEnd('/');
             (bool isList, _, bool isCatalog) = DetectListType(listTemplateType);
 
             // Translate special chars back to their regular values
@@ -52,17 +52,17 @@ namespace PnP.Core.Model.SharePoint
 
                 // Drop List suffix
                 listUrl = listUrl.Substring(0, listUrl.Length - 4);
-                return $"{pnpContextUri}/lists/{listUrl}";
+                return $"{contextUrl}/lists/{listUrl}";
             }
             else if (isCatalog)
             {
                 // catalog
-                return $"{pnpContextUri}/_catalogs/{listUrl}";
+                return $"{contextUrl}/_catalogs/{listUrl}";
             }
             else
             {
                 // library
-                return $"{pnpContextUri}/{listUrl}";
+                return $"{contextUrl}/{listUrl}";
             }
         }
 
@@ -118,8 +118,5 @@ namespace PnP.Core.Model.SharePoint
 
             return (isList, isLibrary, isCatalog);
         }
-
-
-
     }
 }


### PR DESCRIPTION
This is to help fix #312 .

We were adding a double-slash in the list URL (e.g. - "https://gimmalkyle2.sharepoint.com//lists/MyTest")

Question for:
``` c#
                // Drop List suffix
                listUrl = listUrl.Substring(0, listUrl.Length - 4);
                return $"{contextUrl}/lists/{listUrl}";
```

I see we're stripping off "List" from the end using the `.Substring()`.  However, if the language is anything other than English, does that matter (I know it's coming from the `OData_` property bag values)?