### PR TITLE
Added _CommentCount to BuiltInFields

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/BuiltInFields.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/BuiltInFields.cs
@@ -7,6 +7,7 @@ namespace PnP.Core.Model.SharePoint
         private static readonly List<string> internalFields = new List<string>()
         {
             "_CheckinComment",
+            "_CommentCount",
             "_CommentFlags",
             "_ComplianceFlags",
             "_ComplianceTag",


### PR DESCRIPTION
_CommentCount is processed as a lookup field and ends up being null every time when using LoadListDataAsStreamAsync. Adding it to BuiltInFields fixes this.