### PR TITLE
SharePoint ListItem, DateTime field, PM time always turns into AM.

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
@@ -519,7 +519,7 @@ namespace PnP.Core.Model.SharePoint
             DateTime localDateTime = context.Web.RegionalSettings.TimeZone.UtcToLocalTime(inputInUTC);
 
             // Apply the delta from UTC to get the date used by the site and apply formatting 
-            return (localDateTime).ToString("yyyy-MM-dd hh:mm:ss", CultureInfo.InvariantCulture);
+            return (localDateTime).ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
         }
 
         private static string DoubleToSharePointString(PnPContext context, double input)


### PR DESCRIPTION
Maybe the format is wrong, so that 2021-10-22 21:00:00 always becomes 2021-10-22 09:00:00.