### PR TITLE
introduce BoolJsonConverter in order to handle both appearances of addedFromPersistedData

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/WebPartControlData.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/WebPartControlData.cs
@@ -17,6 +17,7 @@ namespace PnP.Core.Model.SharePoint
         public string RteInstanceId { get; set; }
 
         [JsonPropertyName("addedFromPersistedData")]
+        [JsonConverter(typeof(Services.JsonMappingHelper.BoolJsonConverter))]
         public bool AddedFromPersistedData { get; set; }
 
         [JsonPropertyName("reservedHeight")]

--- a/src/sdk/PnP.Core/Services/Core/JsonMappingHelper.cs
+++ b/src/sdk/PnP.Core/Services/Core/JsonMappingHelper.cs
@@ -1695,5 +1695,23 @@ namespace PnP.Core.Services
 
             return null;
         }
+
+        /// <summary>
+        /// Used for Attribute addedFromPersistedData in WebPartControlData as it can be bool or string
+        /// </summary>
+        internal class BoolJsonConverter : System.Text.Json.Serialization.JsonConverter<bool>
+        {
+            public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+            {
+                bool result = false;
+                bool.TryParse(System.Text.Encoding.Default.GetString(reader.ValueSpan.ToArray()), out result);
+                return result;
+            }
+
+            public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+            {
+                writer.WriteBooleanValue(value);
+            }
+        }
     }
 }


### PR DESCRIPTION
#727 created JsonConverter for the attribute in order to handle deserialization of string and bool.