### PR TITLE
suggested fix for Load SiteUsers fails with Error on AadObjectId

### DIFF
--- a/src/sdk/PnP.Core/Model/Base/TransientObject.cs
+++ b/src/sdk/PnP.Core/Model/Base/TransientObject.cs
@@ -124,13 +124,17 @@ namespace PnP.Core.Model
                 string.Format(PnPCoreResources.Exception_PropertyNotLoaded, propertyName));
         }
 
-        protected virtual T GetValue<T>([System.Runtime.CompilerServices.CallerMemberName] string propertyName = "")
+        protected virtual T GetValue<T>([System.Runtime.CompilerServices.CallerMemberName] string propertyName = "", bool allowToBeAbsent=false)
         {
             CheckDeleted();
 
             if (current.TryGetValue(propertyName, out object value))
             {
                 return (T)value;
+            }
+            if(allowToBeAbsent)
+            {
+                return default(T);
             }
 
             throw new ClientException(ErrorType.PropertyNotLoaded,

--- a/src/sdk/PnP.Core/Model/Security/Internal/SharePointUser.cs
+++ b/src/sdk/PnP.Core/Model/Security/Internal/SharePointUser.cs
@@ -17,7 +17,7 @@ namespace PnP.Core.Model.Security
         public int Id { get => GetValue<int>(); set => SetValue(value); }
 
         [SharePointProperty("AadObjectId", JsonPath = "NameId")]
-        public string AadObjectId { get => GetValue<string>(); set => SetValue(value); }
+        public string AadObjectId { get => GetValue<string>("AadObjectId",true); set => SetValue(value); }
 
         public bool IsHiddenInUI { get => GetValue<bool>(); set => SetValue(value); }
 


### PR DESCRIPTION
fix for Error #729 - allows property to be absent in response and return default(T) instead.