### PR TITLE
Fixed wrong ConfigureAwait usage.

### DIFF
--- a/src/sdk/PnP.Core/Model/Base/DataModelExtensions.cs
+++ b/src/sdk/PnP.Core/Model/Base/DataModelExtensions.cs
@@ -60,7 +60,7 @@ namespace PnP.Core.Model
                         await gettableParent.LoadBatchAsync(ensureParentBatch, expressions).ConfigureAwait(false);
 
                         // Make the actual request
-                        await contextAwareParent.PnPContext.BatchClient.ExecuteBatch(ensureParentBatch).ConfigureAwait(true);
+                        await contextAwareParent.PnPContext.BatchClient.ExecuteBatch(ensureParentBatch).ConfigureAwait(false);
                     }
                 }
             }

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1942,7 +1942,7 @@ namespace PnP.Core.Model.SharePoint
             }
             if (hasOneColumnFullWidthSection)
             {
-                await PnPContext.Web.EnsurePropertiesAsync(p => p.WebTemplate).ConfigureAwait(true);
+                await PnPContext.Web.EnsurePropertiesAsync(p => p.WebTemplate).ConfigureAwait(false);
                 if (!PnPContext.Web.WebTemplate.Equals("SITEPAGEPUBLISHING", StringComparison.InvariantCultureIgnoreCase) &&
                     // we allow enabling communication site features on STS and EHS sites, so don't block adding full width sections on those sites
                     !PnPContext.Web.WebTemplate.Equals("STS", StringComparison.InvariantCultureIgnoreCase) &&

--- a/src/sdk/PnP.Core/Services/Core/Query/TokenHandler.cs
+++ b/src/sdk/PnP.Core/Services/Core/Query/TokenHandler.cs
@@ -62,7 +62,7 @@ namespace PnP.Core.Services
                     // Ensure the parent object
                     if (parent != null)
                     {
-                        await ((IDataModelParent)pnpObject).EnsureParentObjectAsync().ConfigureAwait(true);
+                        await ((IDataModelParent)pnpObject).EnsureParentObjectAsync().ConfigureAwait(false);
                     }
 
                     if (parent is IMetadataExtensible p)
@@ -94,7 +94,7 @@ namespace PnP.Core.Services
                     // Ensure the parent object
                     if (parent != null)
                     {
-                        await ((IDataModelParent)pnpObject).EnsureParentObjectAsync().ConfigureAwait(true);
+                        await ((IDataModelParent)pnpObject).EnsureParentObjectAsync().ConfigureAwait(false);
                     }
 
                     if (parent is IMetadataExtensible p)


### PR DESCRIPTION
The title is quite self-explanatory. `ConfigureAwait(true)` doesn't make sense, because it's default behaviour, in "library" projects we should always use  `ConfigureAwait(false)`. I believe `true` that was added by mistake. 