### PR TITLE
Fixed link to getting started

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ The PnP Core SDK is an SDK designed to work for Microsoft 365. It provides a uni
 
 ## Getting started using this library
 
-Using the PnP Core SDK is simple, check out the [getting started](~/using-the-sdk/readme.md) guide.
+Using the PnP Core SDK is simple, check out the [getting started](./using-the-sdk/readme.md) guide.
 
 ## Where is the code?
 


### PR DESCRIPTION
The getting started link on pnpcore/docs/index.md was causing a 404. Replaced "~/using-the-sdk/readme.md" with "./using-the-sdk/readme.md"