### PR TITLE
Search sort direction

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Web.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Web.cs
@@ -1586,7 +1586,7 @@ namespace PnP.Core.Model.SharePoint
                     results = query.SortProperties.Select(o => new
                     {
                         Property = o.Property,
-                        Direction = (int)o.Sort,
+                        Direction = o.Sort,
                     }).ToArray()
                 };
             }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/SortDirection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/SortDirection.cs
@@ -6,13 +6,13 @@
     public enum SortDirection
     {
         /// <summary>
-        /// Sort descending
-        /// </summary>
-        Descending,
-
-        /// <summary>
         /// Sort ascending
         /// </summary>
-        Ascending
+        Ascending = 0,
+
+        /// <summary>
+        /// Sort descending
+        /// </summary>
+        Descending = 1
     }
 }


### PR DESCRIPTION
Fixes a bug introduced by the switch from GET to POST search query by aligning the SortDirection enum with System.ComponentModel.ListSortDirection (Ascending = 0). This was previously passed as a string but POST model requires it as an int.