### PR TITLE
Adding ability to specify ResourceBehaviorOptions when creating a Group

### DIFF
--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
@@ -65,5 +65,11 @@ namespace PnP.Core.Admin.Model.Microsoft365
         /// If it is a security enabled group
         /// </summary>
         public bool SecurityEnabled { get; } = false;
+
+        /// <summary>
+        /// Allows defining the resource behavior options for the group
+        /// See https://learn.microsoft.com/en-us/graph/group-set-options#configure-groups
+        /// </summary>
+        public GraphGroupResourceBehaviorOptions ResourceBehaviorOptions { get; set; }
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
@@ -70,6 +70,6 @@ namespace PnP.Core.Admin.Model.Microsoft365
         /// Allows defining the resource behavior options for the group
         /// See https://learn.microsoft.com/en-us/graph/group-set-options#configure-groups
         /// </summary>
-        public GraphGroupResourceBehaviorOptions ResourceBehaviorOptions { get; set; }
+        public List<string> ResourceBehaviorOptions { get; set; }
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupResourceBehaviorOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupResourceBehaviorOptions.cs
@@ -1,0 +1,44 @@
+﻿namespace PnP.Core.Admin.Model.Microsoft365
+{
+    /// <summary>
+    /// Contains the available resourceBehaviorOptions for creating a group with Graph Api
+    /// See https://learn.microsoft.com/en-us/graph/group-set-options#configure-groups
+    /// </summary>
+    public class GraphGroupResourceBehaviorOptions
+    {
+        /// <summary>
+        /// If true, only group members can post conversations to the group.
+        /// </summary>
+        public bool AllowOnlyMembersToPost { get; set; } = false;
+
+        /// <summary>
+        /// If true, members can view the group calendar in Outlook but cannot make changes.
+        /// </summary>
+        public bool CalendarMemberReadOnly { get; set; } = false;
+
+        /// <summary>
+        /// If true, changes made to the group in Exchange Online are not synced back to on-premises Active Directory.
+        /// </summary>
+        public bool ConnectorsDisabled { get; set; } = false;
+
+        /// <summary>
+        /// If true, this group is hidden in Outlook experiences.
+        /// </summary>
+        public bool HideGroupInOutlook { get; set; } = false;
+
+        /// <summary>
+        /// If true, members are not subscribed to the group's calendar events in Outlook.
+        /// </summary>
+        public bool SubscribeMembersToCalendarEventsDisabled { get; set; } = true;
+
+        /// <summary>
+        /// If true, group members are subscribed to receive group conversations.
+        /// </summary>
+        public bool SubscribeNewGroupMembers { get; set; } = false;
+
+        /// <summary>
+        /// If true, welcome emails are not sent to new members.
+        /// </summary>
+        public bool WelcomeEmailDisabled { get; internal set; } = false;
+    }
+}

--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupResourceBehaviorOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupResourceBehaviorOptions.cs
@@ -39,6 +39,6 @@
         /// <summary>
         /// If true, welcome emails are not sent to new members.
         /// </summary>
-        public bool WelcomeEmailDisabled { get; internal set; } = false;
+        public bool WelcomeEmailDisabled { get; set; } = false;
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
@@ -193,7 +193,43 @@ namespace PnP.Core.Admin.Model.SharePoint
                     Visibility = siteToCreate.IsPublic ? GroupVisibility.Public.ToString() : GroupVisibility.Private.ToString(),
                     GroupTypes = new List<string> { "Unified" },
                     Owners = siteToCreate.Owners,
+                    ResourceBehaviorOptions = new List<string>()
                 };
+
+                if(siteToCreate.AllowOnlyMembersToPost.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("AllowOnlyMembersToPost");
+                }
+
+                if (siteToCreate.CalendarMemberReadOnly.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("CalendarMemberReadOnly");
+                }
+
+                if (siteToCreate.ConnectorsDisabled.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("ConnectorsDisabled");
+                }
+
+                if (siteToCreate.HideGroupInOutlook.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("HideGroupInOutlook");
+                }
+
+                if (siteToCreate.SubscribeMembersToCalendarEventsDisabled.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("SubscribeMembersToCalendarEventsDisabled");
+                }
+
+                if (siteToCreate.SubscribeNewGroupMembers.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("SubscribeNewGroupMembers");
+                }
+
+                if (siteToCreate.WelcomeEmailDisabled.GetValueOrDefault(false))
+                {
+                    newGroup.ResourceBehaviorOptions.Add("WelcomeEmailDisabled");
+                }
 
                 if (siteToCreate.PreferredDataLocation.HasValue)
                 {

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/TeamSiteOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/TeamSiteOptions.cs
@@ -60,6 +60,6 @@ namespace PnP.Core.Admin.Model.SharePoint
         /// <summary>
         /// If true, welcome emails are not sent to new members.
         /// </summary>
-        public bool? WelcomeEmailDisabled { get; internal set; }
+        public bool? WelcomeEmailDisabled { get; set; }
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/TeamSiteOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/TeamSiteOptions.cs
@@ -26,5 +26,40 @@ namespace PnP.Core.Admin.Model.SharePoint
         /// The ID of the Site Design to apply, if any (not applicable when application permissions are used)
         /// </summary>
         public Guid? SiteDesignId { get; set; }
+
+        /// <summary>
+        /// If true, only group members can post conversations to the group.
+        /// </summary>
+        public bool? AllowOnlyMembersToPost { get; set; }
+
+        /// <summary>
+        /// If true, members can view the group calendar in Outlook but cannot make changes.
+        /// </summary>
+        public bool? CalendarMemberReadOnly { get; set; }
+
+        /// <summary>
+        /// If true, changes made to the group in Exchange Online are not synced back to on-premises Active Directory.
+        /// </summary>
+        public bool? ConnectorsDisabled { get; set; }
+
+        /// <summary>
+        /// If true, this group is hidden in Outlook experiences.
+        /// </summary>
+        public bool? HideGroupInOutlook { get; set; }
+
+        /// <summary>
+        /// If true, members are not subscribed to the group's calendar events in Outlook.
+        /// </summary>
+        public bool? SubscribeMembersToCalendarEventsDisabled { get; set; }
+
+        /// <summary>
+        /// If true, group members are subscribed to receive group conversations.
+        /// </summary>
+        public bool? SubscribeNewGroupMembers { get; set; }
+
+        /// <summary>
+        /// If true, welcome emails are not sent to new members.
+        /// </summary>
+        public bool? WelcomeEmailDisabled { get; internal set; }
     }
 }


### PR DESCRIPTION
Added option to specify the [ResourceBehaviorOptions](https://learn.microsoft.com/en-us/graph/group-set-options#configure-groups) when creating a Microsoft 365 Group using the code like provided in this sample: https://pnp.github.io/pnpcore/using-the-sdk/admin-sharepoint-sites.html#basic-site-collection-creation-flow