### PR TITLE
Adding missing property `IsVisible` property to AdaptiveCardAction

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/Viva/AdaptiveCardExtensions/AdaptiveCardAction.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/Viva/AdaptiveCardExtensions/AdaptiveCardAction.cs
@@ -14,10 +14,16 @@ namespace PnP.Core.Model.SharePoint
         public string Title { get; set; }
 
         /// <summary>
-        /// Supported values: positive or defailt
+        /// Supported values: positive or default
         /// </summary>
         [JsonPropertyName("style")]
         public string Style { get; set; }
+
+        /// <summary>
+        /// Is the button visible
+        /// </summary>
+        [JsonPropertyName("isVisible")]
+        public bool? IsVisible { get; set; }
 
         /// <summary>
         /// Action to execute


### PR DESCRIPTION
The IsVisible property is missing on the AdaptiveCard causing an update to the adaptivecard using its typed properties to wipe out the action button on the card by having it default back to false visibility. Adding this property in fixes that.