### PR TITLE
The JSON value could not be converted to System.Int32 : Handle Pnp Provisioning template extraction failure from Project Management site template

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasPosition.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasPosition.cs
@@ -18,7 +18,7 @@ namespace PnP.Core.Model.SharePoint
         /// Gets or sets JsonProperty "sectionIndex"
         /// </summary>
         [JsonPropertyName("sectionIndex")]
-        public int SectionIndex { get; set; }
+        public float SectionIndex { get; set; }
 
         /// <summary>
         /// Gets or sets JsonProperty "sectionFactor"

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1188,7 +1188,7 @@ namespace PnP.Core.Model.SharePoint
                             {
                                 if (sectionData.Position.LayoutIndex.HasValue)
                                 {
-                                    currentSection.AddColumn(new CanvasColumn(currentSection, sectionData.Position.SectionIndex, sectionData.Position.SectionFactor, sectionData.Position.LayoutIndex.Value));
+                                    currentSection.AddColumn(new CanvasColumn(currentSection, (int)sectionData.Position.SectionIndex, sectionData.Position.SectionFactor, sectionData.Position.LayoutIndex.Value));
                                     currentColumn = currentSection.Columns.Where(p => p.Order == sectionData.Position.SectionIndex && p.LayoutIndex == sectionData.Position.LayoutIndex.Value).First();
 
                                     // ZoneEmphasis on a vertical section column needs to be retained as that "overrides" the zone emphasis set on the section
@@ -1199,7 +1199,7 @@ namespace PnP.Core.Model.SharePoint
                                 }
                                 else
                                 {
-                                    currentSection.AddColumn(new CanvasColumn(currentSection, sectionData.Position.SectionIndex, sectionData.Position.SectionFactor));
+                                    currentSection.AddColumn(new CanvasColumn(currentSection, (int)sectionData.Position.SectionIndex, sectionData.Position.SectionFactor));
                                     currentColumn = currentSection.Columns.Where(p => p.Order == sectionData.Position.SectionIndex).First();
                                 }
                             }
@@ -1435,7 +1435,7 @@ namespace PnP.Core.Model.SharePoint
                 {
                     if (position.LayoutIndex.HasValue)
                     {
-                        (currentSection as CanvasSection).AddColumn(new CanvasColumn(currentSection as CanvasSection, position.SectionIndex, position.SectionFactor, position.LayoutIndex.Value));
+                        (currentSection as CanvasSection).AddColumn(new CanvasColumn(currentSection as CanvasSection, (int)position.SectionIndex, position.SectionFactor, position.LayoutIndex.Value));
                         currentColumn = currentSection.Columns.Where(p => p.Order == position.SectionIndex && p.LayoutIndex == position.LayoutIndex.Value).First();
 
                         // ZoneEmphasis on a vertical section column needs to be retained as that "overrides" the zone emphasis set on the section
@@ -1446,7 +1446,7 @@ namespace PnP.Core.Model.SharePoint
                     }
                     else
                     {
-                        (currentSection as CanvasSection).AddColumn(new CanvasColumn(currentSection as CanvasSection, position.SectionIndex, position.SectionFactor));
+                        (currentSection as CanvasSection).AddColumn(new CanvasColumn(currentSection as CanvasSection, (int)position.SectionIndex, position.SectionFactor));
                         currentColumn = currentSection.Columns.Where(p => p.Order == position.SectionIndex).First();
                     }
                 }


### PR DESCRIPTION
[Cant extract Pnp Provisioning template from Project Management site template](https://github.com/pnp/powershell/discussions/2421)

Get-PnPSiteTemplate fails with the following error.

`The JSON value could not be converted to System.Int32. Path: $.position.sectionIndex | LineNumber: 0 | BytePositionInLine: 107.`

The issue is in [pnpcore](https://github.com/pnp/pnpcore) while Deserializing the [controlDataJson](https://github.com/pnp/pnpcore/blob/dev/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasControl.cs#L331).

The sample JSON for which the failure occurs:

`controlDataJson: {"controlType":4,"id":"00000000-0000-0000-0000-100000000005","position":{"zoneIndex":1.0,"sectionIndex":2.0,"controlIndex":2.0,"sectionFactor":6,"layoutIndex":1},"emphasis":{}}`

`controlDataJson: {"controlType":3,"id":"00000000-0000-0000-0000-100000000006","position":{"zoneIndex":1.0,"sectionIndex":2.0,"controlIndex":3.0,"sectionFactor":6,"layoutIndex":1},"webPartId":"8654b779-4886-46d4-8ffb-b5ed960ee986","emphasis":{},"addedFromPersistedData":true}`

The parser is failing to read `"sectionIndex":2.0` property which is defend as `int` in [CanvasPosition.cs](https://github.com/pnp/pnpcore/blob/dev/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasPosition.cs#L21) but the actual value in JSON is `float`

