### PR TITLE
Description uses wrong function name

### DIFF
--- a/docs/using-the-sdk/basics-pnpframework.md
+++ b/docs/using-the-sdk/basics-pnpframework.md
@@ -44,7 +44,7 @@ using (PnPContext pnpCoreContext = PnPCoreSdk.Instance.GetPnPContext(csomContext
 
 ## Using PnP Framework when the PnP Core SDK was already configured
 
-If you already have a PnP Core SDK context and you want also use PnP Framework and/or SharePoint CSOM then you can create a CSOM ClientContext from your PnP Context via the `PnPCoreSDK.Instance.GetContext()` method.
+If you already have a PnP Core SDK context and you want also use PnP Framework and/or SharePoint CSOM then you can create a CSOM ClientContext from your PnP Context via the `PnPCoreSDK.Instance.GetClientContext()` method.
 
 ```csharp
 using (var pnpCoreContext = await pnpContextFactory.CreateAsync("SiteToWorkWith"))


### PR DESCRIPTION
The description above the code example uses the wrong function name, this can be confusing. The code example itself is correct.