### PR TITLE
feat(teams): more options for creating channel

### DIFF
--- a/src/sdk/PnP.Core/Model/Teams/Internal/TeamChannelCollection.cs
+++ b/src/sdk/PnP.Core/Model/Teams/Internal/TeamChannelCollection.cs
@@ -21,24 +21,34 @@ namespace PnP.Core.Model.Teams
         /// Adds a new channel
         /// </summary>
         /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public async Task<ITeamChannel> AddAsync(string name, TeamChannelOptions options)
+        {
+            var newChannel = CreateNewAndAdd(name, options);
+            return await newChannel.AddAsync().ConfigureAwait(false) as TeamChannel;
+        }
+
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public async Task<ITeamChannel> AddAsync(string name, string description = null)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            return await AddAsync(name, new TeamChannelOptions(description)).ConfigureAwait(false);
+        }
 
-            // TODO: validate name restrictions
-
-            var newChannel = CreateNewAndAdd() as TeamChannel;
-
-            // Assign field values
-            newChannel.DisplayName = name;
-            newChannel.Description = description;
-
-            return await newChannel.AddAsync().ConfigureAwait(false) as TeamChannel;
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel Add(string name, TeamChannelOptions options)
+        {
+            return AddAsync(name, options).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -57,22 +67,36 @@ namespace PnP.Core.Model.Teams
         /// </summary>
         /// <param name="batch">Batch to use</param>
         /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public async Task<ITeamChannel> AddBatchAsync(Batch batch, string name, TeamChannelOptions options)
+        {
+            var newChannel = CreateNewAndAdd(name, options);
+            return await newChannel.AddBatchAsync(batch).ConfigureAwait(false) as TeamChannel;
+        }
+
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="batch">Batch to use</param>
+        /// <param name="name">Display name of the channel</param>
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public async Task<ITeamChannel> AddBatchAsync(Batch batch, string name, string description = null)
         {
-            if (string.IsNullOrEmpty(name))
-            {
-                throw new ArgumentNullException(nameof(name));
-            }
+            return await AddBatchAsync(name, new TeamChannelOptions(description)).ConfigureAwait(false);
+        }
 
-            var newChannel = CreateNewAndAdd() as TeamChannel;
-
-            // Assign field values
-            newChannel.DisplayName = name;
-            newChannel.Description = description;
-
-            return await newChannel.AddBatchAsync(batch).ConfigureAwait(false) as TeamChannel;
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="batch">Batch to use</param>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel AddBatch(Batch batch, string name, TeamChannelOptions options)
+        {
+            return AddBatchAsync(batch, name, options).GetAwaiter().GetResult();
         }
 
         /// <summary>
@@ -91,6 +115,17 @@ namespace PnP.Core.Model.Teams
         /// Adds a new channel
         /// </summary>
         /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public async Task<ITeamChannel> AddBatchAsync(string name, TeamChannelOptions options)
+        {
+            return await AddBatchAsync(PnPContext.CurrentBatch, name, options).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public async Task<ITeamChannel> AddBatchAsync(string name, string description = null)
@@ -102,11 +137,48 @@ namespace PnP.Core.Model.Teams
         /// Adds a new channel
         /// </summary>
         /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel AddBatch(string name, TeamChannelOptions options)
+        {
+            return AddBatchAsync(name, options).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public ITeamChannel AddBatch(string name, string description = null)
         {
             return AddBatchAsync(name, description).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Creates a new `TeamChannel` instance,
+        /// adds it to the collection and configures it.
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException">Missing name argument</exception>
+        private TeamChannel CreateNewAndAdd(string name, TeamChannelOptions options)
+        {
+            if (string.IsNullOrEmpty(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+            
+            // TODO: validate name restrictions
+            
+            var newChannel = CreateNewAndAdd() as TeamChannel;
+            
+            newChannel.DisplayName = name;
+            newChannel.Description = options.Description;
+            if(options.MembershipType.HasValue) newChannel.MembershipType = options.MembershipType.Value;
+
+            return newChannel;
         }
 
         #endregion

--- a/src/sdk/PnP.Core/Model/Teams/Public/ITeamChannelCollection.cs
+++ b/src/sdk/PnP.Core/Model/Teams/Public/ITeamChannelCollection.cs
@@ -14,6 +14,14 @@ namespace PnP.Core.Model.Teams
     public interface ITeamChannelCollection : IQueryable<ITeamChannel>, IAsyncEnumerable<ITeamChannel>, IDataModelCollection<ITeamChannel>, IDataModelCollectionLoad<ITeamChannel>, IDataModelCollectionDeleteByStringId, ISupportModules<ITeamChannelCollection>
     {
         #region Add methods
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public Task<ITeamChannel> AddAsync(string name, TeamChannelOptions options);
 
         /// <summary>
         /// Adds a new channel
@@ -22,6 +30,14 @@ namespace PnP.Core.Model.Teams
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public Task<ITeamChannel> AddAsync(string name, string description = null);
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel Add(string name, TeamChannelOptions options);
 
         /// <summary>
         /// Adds a new channel
@@ -36,9 +52,27 @@ namespace PnP.Core.Model.Teams
         /// </summary>
         /// <param name="batch">Batch to use</param>
         /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public Task<ITeamChannel> AddBatchAsync(Batch batch, string name, TeamChannelOptions options);
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="batch">Batch to use</param>
+        /// <param name="name">Display name of the channel</param>
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public Task<ITeamChannel> AddBatchAsync(Batch batch, string name, string description = null);
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="batch">Batch to use</param>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel AddBatch(Batch batch, string name, TeamChannelOptions options);
 
         /// <summary>
         /// Adds a new channel
@@ -48,6 +82,14 @@ namespace PnP.Core.Model.Teams
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public ITeamChannel AddBatch(Batch batch, string name, string description = null);
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public Task<ITeamChannel> AddBatchAsync(string name, TeamChannelOptions options);
 
         /// <summary>
         /// Adds a new channel
@@ -56,6 +98,14 @@ namespace PnP.Core.Model.Teams
         /// <param name="description">Optional description of the channel</param>
         /// <returns>Newly added channel</returns>
         public Task<ITeamChannel> AddBatchAsync(string name, string description = null);
+        
+        /// <summary>
+        /// Adds a new channel
+        /// </summary>
+        /// <param name="name">Display name of the channel</param>
+        /// <param name="options">Options for creating the channel</param>
+        /// <returns>Newly added channel</returns>
+        public ITeamChannel AddBatch(string name, TeamChannelOptions options);
 
         /// <summary>
         /// Adds a new channel

--- a/src/sdk/PnP.Core/Model/Teams/Public/Options/TeamChannelOptions.cs
+++ b/src/sdk/PnP.Core/Model/Teams/Public/Options/TeamChannelOptions.cs
@@ -1,0 +1,30 @@
+﻿namespace PnP.Core.Model.Teams
+{
+    /// <summary>
+    /// Available options for Teams channel
+    /// </summary>
+    public class TeamChannelOptions 
+    {
+        /// <summary>
+        /// Gets or sets the channel description.
+        /// </summary>
+        public string Description { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the channel membership type.
+        ///
+        /// The membership type cannot be changed for existing channels.
+        /// </summary>
+        public TeamChannelMembershipType? MembershipType { get; set; }
+
+        /// <summary>
+        /// Creates a new `TeamChannelOptions` instance
+        /// with the provided description. 
+        /// </summary>
+        /// <param name="description">The channel description.</param>
+        public TeamChannelOptions(string description = null)
+        {
+            Description = description;
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to create team channels using a `TeamChannelOptions` object, which currently includes:

- `Description` - Already present
- `MembershipType` - Main incentive, since you can only set this at channel creation time.