### PR TITLE
fixed issue where section collapsibility is not set correctly when provisioning a clientsidepage with a collapsible section containing a webpart.

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -287,7 +287,7 @@ namespace PnP.Core.Model.SharePoint
                     controlData.ZoneGroupMetadata = new SectionZoneGroupMetadata()
                     {
                         // Set section type to 1 if it was not set (when new sections are added via code)
-                        Type = (Section as CanvasSection).SectionType,
+                        Type = (Section as CanvasSection).SectionType == 0 ? 1 : (Section as CanvasSection).SectionType,
                         DisplayName = Section.DisplayName,
                         IsExpanded = Section.IsExpanded,
                         ShowDividerLine = Section.ShowDividerLine,


### PR DESCRIPTION
fixed issue where section collapsibility is not set correctly when provisioning a clientsidepage with a collapsible section containing a webpart.

see this bugreport for more information: https://github.com/pnp/pnpframework/issues/833
also fixed in this fork of the project https://github.com/WikiTransformationProject/pnpcore/commit/c7612bd19c4407319a4c7961602931bfbd6b27e2