### PR TITLE
IconAlignment cannot be used to infer collapsibility

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1545,7 +1545,7 @@ namespace PnP.Core.Model.SharePoint
         {
             if (zoneGroupMetadata != null)
             {
-                currentSection.Collapsible = zoneGroupMetadata.IconAlignment != null ? true : false;
+                currentSection.Collapsible = zoneGroupMetadata.Type == 1;
                 currentSection.SectionType = zoneGroupMetadata.Type;
                 currentSection.DisplayName = zoneGroupMetadata.DisplayName;
                 currentSection.IsExpanded = zoneGroupMetadata.IsExpanded;


### PR DESCRIPTION
We can't rely on the IconAlignment property to figure out if the section is collapsible, because enabling and then disabling collapsiblity on a section will retain a value for the IconAlignment. Instead, look at the section type to figure out if the section should be expandable.