### PR TITLE
Vertical sections should not be collapsible

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageText.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageText.cs
@@ -102,7 +102,7 @@ namespace PnP.Core.Model.SharePoint
             };
 
             // Persist the collapsible section settings
-            if (Section.Collapsible)
+            if (Section.Collapsible && !Column.IsVerticalSectionColumn)
             {
                 controlData.ZoneGroupMetadata = new SectionZoneGroupMetadata()
                 {

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -282,7 +282,7 @@ namespace PnP.Core.Model.SharePoint
                 };
 
                 // Persist the collapsible section settings
-                if (Section.Collapsible)
+                if (Section.Collapsible && !Column.IsVerticalSectionColumn)
                 {
                     controlData.ZoneGroupMetadata = new SectionZoneGroupMetadata()
                     {


### PR DESCRIPTION
When you have a client side page with a vertical section, the vertical section should not be set as expandable just because the "parent" section is. In fact, it is not possible to set the vertical section as expandable in the sharepoint editor, and as such I've removed the possiblity for vertical section columns to be set as collapsible.