### PR TITLE
Add SectionType property of CanvasSection to public model

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/ICanvasSection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/ICanvasSection.cs
@@ -48,7 +48,7 @@ namespace PnP.Core.Model.SharePoint
         int ZoneEmphasis { get; set; }
 
         /// <summary>
-        /// Is this section collapsible?
+        /// Is this section collapsible? When setting to true, also set SectionType to 1
         /// </summary>
         bool Collapsible { get; set; }
 
@@ -71,5 +71,10 @@ namespace PnP.Core.Model.SharePoint
         /// Show a devided line for this collapsible section?
         /// </summary>
         bool ShowDividerLine { get; set; }
+
+        /// <summary>
+        /// Is the section collapsible? 0 - non collapsible, 1 - collapsible
+        /// </summary>
+        public int SectionType { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds SectionType property to ICanvasSection interface, so the property may be utilized in public model.
I am working on a PR for pnpframework, extending PNP Provisioning to support collapsible sections. In order to properly implement it, I need to extend ICanvasSection with SectionType first (as pnpframework utilizes that interface).  