### PR TITLE
Added creation options so we can create team site with the graph api for application and delegated permissions

### DIFF
--- a/docs/using-the-sdk/admin-sharepoint-sites.md
+++ b/docs/using-the-sdk/admin-sharepoint-sites.md
@@ -98,7 +98,7 @@ It's highly recommended to use one of the "modern" site collections as these off
 Category | Delegated permissions | Application permissions
 ---------|-----------------------|------------------------
 Modern, no group | Use `CommunicationSiteOptions` or `TeamSiteWithoutGroupOptions` | Use `CommunicationSiteOptions` or `TeamSiteWithoutGroupOptions`. The `Owner` property must be set.
-Modern, with group | Use `TeamSiteOptions`. The `AllowOnlyMembersToPost`, `CalendarMemberReadOnly`, `ConnectorsDisabled`, `HideGroupInOutlook`, `SubscribeMembersToCalendarEventsDisabled`, `SubscribeNewGroupMembers`, `WelcomeEmailDisabled` and `Members` properties are not applicable here. | Use `TeamSiteOptions`.  The `Owners` property must be set, properties `Language`, `SiteDesignId`, `HubSiteId`, `SensitivityLabelId` and `SiteAlias` are not applicable here.
+Modern, with group | Use `TeamSiteOptions`.  The Owners property must be set.  | Use `TeamSiteOptions`.  The `Owners` property must be set.
 Classic site | Use `ClassicSiteOptions` | Use `ClassicSiteOptions`
 
 All provisioning flows will only return once the site collection is done, for the modern sites this is a matter of seconds, for classic sites this can take up to 10-15 minutes.

--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
@@ -70,5 +70,10 @@ namespace PnP.Core.Admin.Model.Microsoft365
         /// See https://learn.microsoft.com/en-us/graph/group-set-options#configure-groups
         /// </summary>
         public List<string> ResourceBehaviorOptions { get; set; }
+
+        /// <summary>
+        /// Allows defining creation options for SharePoint Site Creation
+        /// </summary>
+        public List<string> CreationOptions { get; set; }
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
@@ -187,149 +187,96 @@ namespace PnP.Core.Admin.Model.SharePoint
 
         private static async Task<PnPContext> CreateTeamSiteAsync(PnPContext context, TeamSiteOptions siteToCreate, SiteCreationOptions creationOptions)
         {
-            // If we're using application permissions we use Microsoft Graph to create the site
-            if (creationOptions.UsingApplicationPermissions.Value)
+            var newGroup = new GraphGroupOptions
             {
-                var newGroup = new GraphGroupOptions
-                {
-                    DisplayName = siteToCreate.DisplayName,
-                    MailNickname = siteToCreate.Alias,
-                    MailEnabled = true,
-                    Visibility = siteToCreate.IsPublic ? GroupVisibility.Public.ToString() : GroupVisibility.Private.ToString(),
-                    GroupTypes = new List<string> { "Unified" },
-                    Owners = siteToCreate.Owners,
-                    Members = siteToCreate.Members,
-                    ResourceBehaviorOptions = new List<string>()
-                };
+                DisplayName = siteToCreate.DisplayName,
+                MailNickname = siteToCreate.Alias,
+                MailEnabled = true,
+                Visibility = siteToCreate.IsPublic ? GroupVisibility.Public.ToString() : GroupVisibility.Private.ToString(),
+                GroupTypes = new List<string> { "Unified" },
+                Owners = siteToCreate.Owners,
+                Members = siteToCreate.Members,
+                ResourceBehaviorOptions = new List<string>(),
+                CreationOptions = new List<string>(),
+            };
 
-                if (!string.IsNullOrEmpty(siteToCreate.Description))
-                {
-                    newGroup.Description = siteToCreate.Description;
-                }
-                
-                if (siteToCreate.AllowOnlyMembersToPost.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("AllowOnlyMembersToPost");
-                }
-
-                if (siteToCreate.CalendarMemberReadOnly.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("CalendarMemberReadOnly");
-                }
-
-                if (siteToCreate.ConnectorsDisabled.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("ConnectorsDisabled");
-                }
-
-                if (siteToCreate.HideGroupInOutlook.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("HideGroupInOutlook");
-                }
-
-                if (siteToCreate.SubscribeMembersToCalendarEventsDisabled.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("SubscribeMembersToCalendarEventsDisabled");
-                }
-
-                if (siteToCreate.SubscribeNewGroupMembers.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("SubscribeNewGroupMembers");
-                }
-
-                if (siteToCreate.WelcomeEmailDisabled.GetValueOrDefault(false))
-                {
-                    newGroup.ResourceBehaviorOptions.Add("WelcomeEmailDisabled");
-                }
-
-                if (siteToCreate.PreferredDataLocation.HasValue)
-                {
-                    newGroup.PreferredDataLocation = siteToCreate.PreferredDataLocation.Value.ToString();
-                }
-
-                if (!string.IsNullOrEmpty(siteToCreate.Classification))
-                {
-                    newGroup.Classification = siteToCreate.Classification;
-                }
-
-                Microsoft365.CreationOptions groupCreationOptions = new Microsoft365.CreationOptions
-                {
-                    MaxStatusChecks = creationOptions.MaxStatusChecks,
-                    WaitAfterStatusCheck = creationOptions.WaitAfterStatusCheck,
-                };
-
-                return await context.GetMicrosoft365Admin().CreateGroupAsync(newGroup, groupCreationOptions).ConfigureAwait(false);
-            }
-            else
+            if (!string.IsNullOrEmpty(siteToCreate.Description))
             {
-                var creationOptionsValues = new List<string>();
-                Dictionary<string, object> payload = new Dictionary<string, object>
-                {
-                    { "displayName", siteToCreate.DisplayName },
-                    { "alias", NormalizeSiteAlias(siteToCreate.Alias) },
-                    { "isPublic", siteToCreate.IsPublic }
-                };
-
-                var optionalParams = new Dictionary<string, object>
-                {
-                    { "Description", siteToCreate.Description ?? "" }
-                };
-
-                // Sensitivity labels have replaced classification (see https://docs.microsoft.com/en-us/microsoft-365/compliance/sensitivity-labels-teams-groups-sites?view=o365-worldwide#classic-azure-ad-group-classification)
-                // once enabled. Therefore we prefer setting a sensitivity label id over classification when specified. Also note that for setting sensitivity labels on 
-                // group connected sites one needs to have at least one Azure AD P1 license. See https://docs.microsoft.com/en-us/azure/active-directory/enterprise-users/groups-assign-sensitivity-labels
-                if (siteToCreate.SensitivityLabelId != Guid.Empty)
-                {
-                    creationOptionsValues.Add($"SensitivityLabel:{siteToCreate.SensitivityLabelId}");
-                }
-                else
-                {
-                    optionalParams.Add("Classification", siteToCreate.Classification ?? "");
-                }
-
-                if (siteToCreate.SiteDesignId.HasValue)
-                {
-                    creationOptionsValues.Add($"implicit_formula_292aa8a00786498a87a5ca52d9f4214a_{siteToCreate.SiteDesignId.Value.ToString("D").ToLower()}");
-                }
-                if (siteToCreate.Language != Language.Default)
-                {
-                    creationOptionsValues.Add($"SPSiteLanguage:{(int)siteToCreate.Language}");
-                }
-                if (!string.IsNullOrEmpty(siteToCreate.SiteAlias))
-                {
-                    creationOptionsValues.Add($"SiteAlias:{siteToCreate.SiteAlias}");
-                }
-                creationOptionsValues.Add($"HubSiteId:{siteToCreate.HubSiteId}");
-
-                if (siteToCreate.Owners != null && siteToCreate.Owners.Length > 0)
-                {
-                    var ownersBody = new
-                    {
-                        __metadata = new { type = "Collection(Edm.String)" },
-                        results = siteToCreate.Owners
-                    }.AsExpando();
-                    optionalParams.Add("Owners", ownersBody);
-                }
-                if (siteToCreate.PreferredDataLocation.HasValue)
-                {
-                    optionalParams.Add("PreferredDataLocation", siteToCreate.PreferredDataLocation.Value.ToString());
-                }
-
-                if (creationOptionsValues.Any())
-                {
-                    var creationOptionsValuesBody = new
-                    {
-                        __metadata = new { type = "Collection(Edm.String)" },
-                        results = creationOptionsValues
-                    }.AsExpando();
-                    optionalParams.Add("CreationOptions", creationOptionsValuesBody);
-                }
-
-                payload.Add("optionalParams", optionalParams);
-
-                // Delegated permissions can use the SharePoint endpoints for site collection creation
-                return await CreateSiteUsingSpoRestImplementationAsync(context, SiteCreationModel.GroupSiteManagerCreateGroupEx, payload, creationOptions).ConfigureAwait(false);
+                newGroup.Description = siteToCreate.Description;
             }
+
+            if (siteToCreate.AllowOnlyMembersToPost.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("AllowOnlyMembersToPost");
+            }
+
+            if (siteToCreate.CalendarMemberReadOnly.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("CalendarMemberReadOnly");
+            }
+
+            if (siteToCreate.ConnectorsDisabled.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("ConnectorsDisabled");
+            }
+
+            if (siteToCreate.HideGroupInOutlook.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("HideGroupInOutlook");
+            }
+
+            if (siteToCreate.SubscribeMembersToCalendarEventsDisabled.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("SubscribeMembersToCalendarEventsDisabled");
+            }
+
+            if (siteToCreate.SubscribeNewGroupMembers.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("SubscribeNewGroupMembers");
+            }
+
+            if (siteToCreate.WelcomeEmailDisabled.GetValueOrDefault(false))
+            {
+                newGroup.ResourceBehaviorOptions.Add("WelcomeEmailDisabled");
+            }
+
+            if (siteToCreate.PreferredDataLocation.HasValue)
+            {
+                newGroup.PreferredDataLocation = siteToCreate.PreferredDataLocation.Value.ToString();
+            }
+
+            if (!string.IsNullOrEmpty(siteToCreate.Classification))
+            {
+                newGroup.Classification = siteToCreate.Classification;
+            }
+
+            if (siteToCreate.SensitivityLabelId != Guid.Empty)
+            {
+                newGroup.CreationOptions.Add($"SensitivityLabel:{siteToCreate.SensitivityLabelId}");
+            }
+
+            if (siteToCreate.SiteDesignId.HasValue)
+            {
+                newGroup.CreationOptions.Add($"implicit_formula_292aa8a00786498a87a5ca52d9f4214a_{siteToCreate.SiteDesignId.Value.ToString("D").ToLower()}");
+            }
+            if (siteToCreate.Language != Language.Default)
+            {
+                newGroup.CreationOptions.Add($"SPSiteLanguage:{(int)siteToCreate.Language}");
+            }
+            if (!string.IsNullOrEmpty(siteToCreate.SiteAlias))
+            {
+                newGroup.CreationOptions.Add($"SiteAlias:{siteToCreate.SiteAlias}");
+            }
+
+            newGroup.CreationOptions.Add($"HubSiteId:{siteToCreate.HubSiteId}");
+
+            Microsoft365.CreationOptions groupCreationOptions = new Microsoft365.CreationOptions
+            {
+                MaxStatusChecks = creationOptions.MaxStatusChecks,
+                WaitAfterStatusCheck = creationOptions.WaitAfterStatusCheck,
+            };
+
+            return await context.GetMicrosoft365Admin().CreateGroupAsync(newGroup, groupCreationOptions).ConfigureAwait(false);
         }
 
         private static async Task<PnPContext> CreateClassicSiteAsync(PnPContext context, ClassicSiteOptions siteToCreate, SiteCreationOptions creationOptions, VanityUrlOptions vanityUrlOptions)


### PR DESCRIPTION
Feature for using the graph api to create a team site with group for both delegeted and app permissions.

What I did was I'm currently using the delegeted way to create a team site with group with language but I got a feature request from my organisation to also support ResourceBehaviorOptions.

But we can't set ResourceBehaviorOptions when using the delegated way. So I was looking at the api calls from sharepoint and found that they post the following data with  creating a team site with group:
```
call: _api/GroupSiteManager/CreateGroupEx
{
    "displayName": "test test test test test v50",
    "alias": "testtesttesttesttestv500",
    "isPublic": false,
    "optionalParams": {
        "Description": "test test test test test v50",
        "Owners": {
            "results": [
                "danielpastoor@...."
            ]
        },
        "CreationOptions": {
            "results": [
                "AllowFileSharingForGuestUsers",
                "SPSiteLanguage:1043",
                "HubSiteId:00000000-0000-0000-0000-000000000000"
            ]
        },
        "Classification": ""
    },
}
```

Then I was curious what the meaning of the "CreationOptions" was. 
Were I found out that it was also stored in the group when I get group with the graph api:

```
call: https://graph.microsoft.com/v1.0/groups/261c3090-2627-4949-b957-06627800bc6e
{
    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups/$entity",
    "id": "261c3090-2627-4949-b957-06627800bc6e",
    "deletedDateTime": null,
    "classification": null,
    "createdDateTime": "2023-07-05T07:53:51Z",
    "creationOptions": [
        "ProvisionGroupHomepage",
        "HubSiteId:00000000-0000-0000-0000-000000000000",
        "SPSiteLanguage:1043",
        "AllowFileSharingForGuestUsers"
    ],
    "description": "test test test test test v50",
    "displayName": "test test test test test v50",
    "expirationDateTime": null,
    "groupTypes": [
        "Unified"
    ],
    "isAssignableToRole": null,
    "mail": "testtesttesttesttestv500@....",
    "mailEnabled": true,
    "mailNickname": "testtesttesttesttestv500",
    "membershipRule": null,
    "membershipRuleProcessingState": null,
    "onPremisesDomainName": null,
    "onPremisesLastSyncDateTime": null,
    "onPremisesNetBiosName": null,
    "onPremisesSamAccountName": null,
    "onPremisesSecurityIdentifier": null,
    "onPremisesSyncEnabled": null,
    "preferredDataLocation": null,
    "preferredLanguage": null,
    "proxyAddresses": [
        "SMTP:testtesttesttesttestv500@...."
    ],
    "renewedDateTime": "2023-07-05T07:53:51Z",
    "resourceBehaviorOptions": [],
    "resourceProvisioningOptions": [],
    "securityEnabled": false,
    "securityIdentifier": "S-1-12-1-639381648-1229530663-1644582841-1857814648",
    "theme": null,
    "visibility": "Private",
    "serviceProvisioningErrors": [],
    "onPremisesProvisioningErrors": []
}
```

And if you look at the call response it contains the `CreationOptions`.
So then I did a request with the graph explorer to test this with delegated permissions if I can create a group with `CreationOptions`

```
call: Post: https://graph.microsoft.com/v1.0/groups
{
    "description": "testtesttesttesttestv556",
    "displayName": "testtesttesttesttestv556",
    "groupTypes": [
        "Unified"
    ],
    "mailEnabled": true,
    "mailNickname": "testtesttesttesttestv556",
    "securityEnabled": false,
    "creationOptions": [
        "ProvisionGroupHomepage",
        "HubSiteId:00000000-0000-0000-0000-000000000000",
        "SPSiteLanguage:1029",
        "AllowFileSharingForGuestUsers"
    ],
    "resourceBehaviorOptions": [
        "HideGroupInOutlook",
        "CalendarMemberReadOnly",
        "WelcomeEmailDisabled ",
        "AllowOnlyMembersToPost"
    ]
}
```
And it succeedded. And when I checked the sharepoint site language it was Czech.

Why I chose Czech. This is because it is a language I do not know and I would recognize the changed sharepoint url.
So I saw that the shared documents url now Sdilene%20dokumenty was.

Then I changed the code in the pnp.core.admin project to check if it works with App permissions and it did.

So that is the reason why I removed the sharepoint api call part and changed it all to the Graph api.
