### PR TITLE
Add Task overload of constructor to external provider to allow it to run async

### DIFF
--- a/src/sdk/PnP.Core.Auth.Test/Providers/ExternalAuthenticationProviderTests.cs
+++ b/src/sdk/PnP.Core.Auth.Test/Providers/ExternalAuthenticationProviderTests.cs
@@ -15,6 +15,7 @@ namespace PnP.Core.Auth.Test.Providers
     [TestClass]
     public class ExternalAuthenticationProviderTests
     {
+        private const string fakeToken = "ThisIsATestToken";
         private static readonly string externalRealProviderConfigurationPath = "externalRealProvider";
 
         private static readonly Lazy<CredentialManagerAuthenticationProvider> realProvider =
@@ -185,18 +186,28 @@ namespace PnP.Core.Auth.Test.Providers
             Assert.IsTrue(accessToken.Length > 0);
         }
 
-        private static ExternalAuthenticationProvider PrepareExternalAuthenticationProvider()
+        private static ExternalAuthenticationProvider PrepareExternalAuthenticationProvider(bool useFakeToken = false, bool useAsyncConstructor = false)
         {
             if (TestCommon.RunningInGitHubWorkflow()) Assert.Inconclusive("Skipping test because we're running inside a GitHub action and we don't have access to the certificate store");
 
-            var provider = new ExternalAuthenticationProvider(
+            Func<Uri, string[], Task<string>> getAccessToken = useFakeToken
+                ? (Func<Uri, string[], Task<string>>)GetFakeAccessToken
                 // We get the access token using a CredentialManagerAuthenticationProvider
-                (uri, scopes) => GetAccessToken(uri, scopes).GetAwaiter().GetResult());
+                : GetRealAccessToken;
+
+            var provider = useAsyncConstructor
+            ? new ExternalAuthenticationProvider(getAccessToken)
+            : new ExternalAuthenticationProvider((uri, scopes) => getAccessToken(uri, scopes).GetAwaiter().GetResult());
 
             return provider;
         }
 
-        private static async Task<string> GetAccessToken(Uri resource, string[] scopes)
+        private static Task<string> GetFakeAccessToken(Uri resource, string[] scopes)
+        {
+            return Task.FromResult(fakeToken);
+        }
+
+        private static async Task<string> GetRealAccessToken(Uri resource, string[] scopes)
         {
             return await RealProvider.GetAccessTokenAsync(resource, scopes);
         }

--- a/src/sdk/PnP.Core.Auth/Others/ExternalAuthenticationProvider.cs
+++ b/src/sdk/PnP.Core.Auth/Others/ExternalAuthenticationProvider.cs
@@ -30,7 +30,7 @@ namespace PnP.Core.Auth
             {
                 isAsync = false;
                 accessTokenProvider = value;
-                accessTokenTaskProvider = (uri, scopes) => Task.FromResult(value(uri, scopes));
+                accessTokenTaskProvider = value == null ? null : (uri, scopes) => Task.FromResult(value(uri, scopes));
             }
         }
 
@@ -44,7 +44,7 @@ namespace PnP.Core.Auth
             {
                 isAsync = true;
                 accessTokenTaskProvider = value;
-                accessTokenProvider = (uri, scopes) => value(uri, scopes).GetAwaiter().GetResult();
+                accessTokenProvider = value == null ? null : (uri, scopes) => value (uri, scopes).GetAwaiter().GetResult();
             }
         }
 


### PR DESCRIPTION
Allow passing a Task to the constructor so auth can be done async. Some of the complexity is to ensure it's backwards compatible with existing code.

I don't think the tests are quite right yet, would appreciate some guidance on how best to handle it for this project. Simplest thing to do would be to copy the existing ones but just use the new constructor.

A few things I was thinking about.
- Do the tests actually need to connect to Sharepoint? Would unit tests be sufficient? Perhaps this would be inconsistent with the other areas of the project.
- Constructor could take an interface rather than a Func?
- No use of mocking library? Not sure if you can actually mock a Func.
- In tests could use data attribute to control which constructor to use and whether to use fake version of token provider. Possibly a bit overkill.