### PR TITLE
#1461 Add better support for the Visibility HiddenMembership and added additionaldata support for creating a Group

### DIFF
--- a/src/sdk/PnP.Core.Admin.Test/SharePoint/SiteCreationTests.cs
+++ b/src/sdk/PnP.Core.Admin.Test/SharePoint/SiteCreationTests.cs
@@ -4,6 +4,7 @@ using PnP.Core.Admin.Model.SharePoint;
 using PnP.Core.Admin.Model.Teams;
 using PnP.Core.Admin.Test.Utilities;
 using PnP.Core.Model;
+using PnP.Core.Model.Security;
 using PnP.Core.Model.SharePoint;
 using PnP.Core.QueryModel;
 using PnP.Core.Services;
@@ -450,7 +451,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                     };
 
 
@@ -547,7 +548,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         SensitivityLabelId = sensitivityLabelId
                     };
 
@@ -627,7 +628,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         Owners = new string[] { user.UserPrincipalName }
                     };
 
@@ -706,7 +707,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         Owners = new string[] { user.UserPrincipalName }
                     };
 
@@ -780,7 +781,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     teamSiteToCreate = new TeamSiteOptions(alias, "PnP Core SDK Test")
                     {
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         Owners = new string[] { user.UserPrincipalName }
                     };
 
@@ -862,7 +863,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         Owners = new string[] { testOwner.UserPrincipalName },
                         Members = new string[] { testMember.UserPrincipalName }
                     };
@@ -983,7 +984,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                         Owners = new string[] { user.UserPrincipalName },
                         HideGroupInOutlook = true,
                         WelcomeEmailDisabled = true,
@@ -1325,7 +1326,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                         {
                             Description = "This is a test site collection",
                             Language = Language.English,
-                            IsPublic = true,
+                            Visibility = GroupVisibility.Public,
                         };
 
                         SiteCreationOptions siteCreationOptions = new SiteCreationOptions()
@@ -1661,7 +1662,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                     };
 
 

--- a/src/sdk/PnP.Core.Admin.Test/SharePoint/SiteManagerTests.cs
+++ b/src/sdk/PnP.Core.Admin.Test/SharePoint/SiteManagerTests.cs
@@ -2,6 +2,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PnP.Core.Admin.Model.SharePoint;
 using PnP.Core.Admin.Test.Utilities;
 using PnP.Core.Model;
+using PnP.Core.Model.Security;
 using PnP.Core.QueryModel;
 using PnP.Core.Services;
 using System;
@@ -1269,7 +1270,7 @@ namespace PnP.Core.Admin.Test.SharePoint
                     {
                         Description = "This is a test site collection",
                         Language = Language.English,
-                        IsPublic = true,
+                        Visibility = GroupVisibility.Public,
                     };
 
 

--- a/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/Microsoft365/Public/Options/GraphGroupOptions.cs
@@ -75,5 +75,11 @@ namespace PnP.Core.Admin.Model.Microsoft365
         /// Allows defining creation options for SharePoint Site Creation
         /// </summary>
         public List<string> CreationOptions { get; set; }
+
+        /// <summary>
+        /// Option to add custom data to the post request for creating a group like the custom property for a EducationClass
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; } = null;
     }
 }

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/SiteCollectionCreator.cs
@@ -67,7 +67,7 @@ namespace PnP.Core.Admin.Model.SharePoint
                     {
                         { "displayName", siteToGroupify.DisplayName },
                         { "alias", NormalizeSiteAlias(siteToGroupify.Alias) },
-                        { "isPublic", siteToGroupify.IsPublic }
+                        { "isPublic", siteToGroupify.Visibility == GroupVisibility.Public }
                     };
 
                     var optionalParams = new Dictionary<string, object>
@@ -198,12 +198,13 @@ namespace PnP.Core.Admin.Model.SharePoint
                 DisplayName = siteToCreate.DisplayName,
                 MailNickname = siteToCreate.Alias,
                 MailEnabled = true,
-                Visibility = siteToCreate.IsPublic ? GroupVisibility.Public.ToString() : GroupVisibility.Private.ToString(),
+                Visibility = siteToCreate.Visibility.ToString(),
                 GroupTypes = new List<string> { "Unified" },
                 Owners = siteToCreate.Owners,
                 Members = siteToCreate.Members,
                 ResourceBehaviorOptions = new List<string>(),
                 CreationOptions = new List<string>(),
+                AdditionalData = siteToCreate.AdditionalData
             };
 
             if (!string.IsNullOrEmpty(siteToCreate.Description))

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/CommonGroupSiteOptions.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/Options/CommonGroupSiteOptions.cs
@@ -1,5 +1,7 @@
 ﻿using PnP.Core.Admin.Model.Microsoft365;
+using PnP.Core.Model.Security;
 using System;
+using System.Collections.Generic;
 
 namespace PnP.Core.Admin.Model.SharePoint
 {
@@ -40,9 +42,9 @@ namespace PnP.Core.Admin.Model.SharePoint
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Defines whether the Office 365 Group will be public (default), or private.
+        /// Defines whether the Office 365 Group will be public (default), or private or hiddenMembership.
         /// </summary>
-        public bool IsPublic { get; set; } = true;
+        public GroupVisibility Visibility { get; set; } = GroupVisibility.Public;
 
         /// <summary>
         /// The description of the site to be created.
@@ -73,6 +75,11 @@ namespace PnP.Core.Admin.Model.SharePoint
         /// The geography in which to create the site collection. Only applicable to multi-geo enabled tenants
         /// </summary>
         public GeoLocation? PreferredDataLocation { get; set; }
+
+        /// <summary>
+        /// Option to add custom data to the post request for creating a group like the custom property for a EducationClass
+        /// </summary>
+        public IDictionary<string, object> AdditionalData { get; set; } = null;
 
     }
 }

--- a/src/sdk/PnP.Core/Model/Security/Public/Enums/GroupVisibility.cs
+++ b/src/sdk/PnP.Core/Model/Security/Public/Enums/GroupVisibility.cs
@@ -18,6 +18,6 @@
         /// <summary>
         /// Group is a hidden membership group
         /// </summary>
-        Hiddenmembership
+        HiddenMembership
     }
 }

--- a/src/sdk/PnP.Core/Model/Teams/Public/Enums/TeamVisibility.cs
+++ b/src/sdk/PnP.Core/Model/Teams/Public/Enums/TeamVisibility.cs
@@ -13,6 +13,11 @@
         /// <summary>
         /// Public team
         /// </summary>
-        Public
+        Public,
+
+        /// <summary>
+        /// Team is a hidden membership Team
+        /// </summary>
+        HiddenMembership
     }
 }


### PR DESCRIPTION
#1461 Add better support for the Visibility HiddenMembership when creating a site with group.

And fixed an issue when loading team data if the Visibility is HiddenMembership by adding it to the TeamVisibility.cs enum. And last added support for additional creation properties when creating a Group like the property for creating an Education Class Group.