### PR TITLE
Feature: bump MSAL to 4.61.0 to better support PnP PowerShell

### DIFF
--- a/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
+++ b/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
@@ -47,7 +47,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.1" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
+++ b/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
@@ -47,7 +47,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
+++ b/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />

--- a/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
+++ b/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.60.3" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.1.1" />


### PR DESCRIPTION
Feature: bump MSAL to 4.61.0 to better support PnP PowerShell