### PR TITLE
Update Page.cs and CanvasColumn.cs to handle collapsible sections correctly

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasColumn.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasColumn.cs
@@ -151,6 +151,18 @@ namespace PnP.Core.Model.SharePoint
                     }
                 };
 
+                if (Section.Collapsible)
+                {
+                    clientSideCanvasPosition.ZoneGroupMetadata = new SectionZoneGroupMetadata()
+                    {
+                        IsExpanded = Section.IsExpanded,
+                        DisplayName = Section.DisplayName,
+                        ShowDividerLine = Section.ShowDividerLine,
+                        IconAlignment = Section.IconAlignment == IconAlignment.Right ? "right" : "left",
+                        Type = 1,
+                    };
+                }
+
                 var jsonControlData = JsonSerializer.Serialize(clientSideCanvasPosition);
 
                 html.Append($@"<div {CanvasControlAttribute}="""" {CanvasDataVersionAttribute}=""{DataVersion}"" {ControlDataAttribute}=""{jsonControlData.Replace("\"", "&quot;")}""></div>");

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1235,6 +1235,8 @@ namespace PnP.Core.Model.SharePoint
                             }
                         }
 
+                        ApplyCollapsibleSectionSettings(sectionData.ZoneGroupMetadata, currentSection);
+                        
                         ICanvasColumn currentColumn = null;
                         if (sectionData.Position != null)
                         {


### PR DESCRIPTION
As mentioned in issue #1497, the following PR contains a fix for collapsible sections in SharePoint pages.