### PR TITLE
MS Feature 386904 Support: Page Header divs are removed and settings are now part of the PageTitle-WebPart

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -939,6 +939,14 @@ namespace PnP.Core.Model.SharePoint
             };
         }
 
+        /// <summary>
+        /// Sets page header back to the default for PageTilte WebPart (Message ID: MC791596 / Roadmap ID: 386904). The PageTitle WebPart has to be added into a first OneColumnFullWith Section separate.
+        /// </summary>
+        public void SetPageTitleWebPartPageHeader()
+        {
+            pageHeader = new PageHeader(PnPContext, PageHeaderType.PageTitleWebPart, null);
+        }
+
         #endregion
 
         #region To Html
@@ -1436,6 +1444,10 @@ namespace PnP.Core.Model.SharePoint
             // Reindex the control order. We're starting control order from 1 for each column.
             ReIndex();
 
+            var hasPageTitleWPInOneColumFullWith = false;
+            if (sections.Any() && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth && sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
+                hasPageTitleWPInOneColumFullWith = true; //Message ID: MC791596 / Roadmap ID: 386904
+
             // Load page header controls. Microsoft Syntex Topic pages do have 5 controls in the header (= controls that cannot be moved)
             if (LayoutType == PageLayoutType.Topic || LayoutType == PageLayoutType.NewsDigest)
             {
@@ -1464,8 +1476,11 @@ namespace PnP.Core.Model.SharePoint
             }
             else
             {
-                // Load the page header
-                pageHeader.FromHtml(pageHeaderHtml);
+                if (hasPageTitleWPInOneColumFullWith)
+                    pageHeader = new PageHeader(PnPContext, PageHeaderType.PageTitleWebPart, null);
+                else
+                    // Load the page header
+                    pageHeader.FromHtml(pageHeaderHtml);
             }
         }
 
@@ -1646,16 +1661,21 @@ namespace PnP.Core.Model.SharePoint
             }
 
             var pageHeaderHtml = "";
-            var hasPageTitleWPInOneColumFullWith = false;
-            if (sections.Any() && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth && sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
-                hasPageTitleWPInOneColumFullWith = true; //Message ID: MC791596 / Roadmap ID: 386904
-
-            if (pageHeader != null && pageHeader.Type != PageHeaderType.None && LayoutType != PageLayoutType.RepostPage
-                && LayoutType != PageLayoutType.Topic && LayoutType != PageLayoutType.NewsDigest && !hasPageTitleWPInOneColumFullWith)
+            if (pageHeader != null)
             {
-                // this triggers resolving of the header image which has to be done early as otherwise there will be version conflicts
-                // (see here: https://github.com/SharePoint/PnP-Sites-Core/issues/2203)
-                pageHeaderHtml = await pageHeader.ToHtmlAsync(PageTitle).ConfigureAwait(false);
+                if(pageHeader.Type == PageHeaderType.Default && sections.Any() && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth && sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
+                {
+                    //Page created from code and Header was not set
+                    SetPageTitleWebPartPageHeader();
+                }
+
+                if (pageHeader.Type != PageHeaderType.None && LayoutType != PageLayoutType.RepostPage
+                    && LayoutType != PageLayoutType.Topic && LayoutType != PageLayoutType.NewsDigest && pageHeader.Type != PageHeaderType.PageTitleWebPart)
+                {
+                    // this triggers resolving of the header image which has to be done early as otherwise there will be version conflicts
+                    // (see here: https://github.com/SharePoint/PnP-Sites-Core/issues/2203)
+                    pageHeaderHtml = await pageHeader.ToHtmlAsync(PageTitle).ConfigureAwait(false);
+                }
             }
 
             if (LayoutType == PageLayoutType.Topic || LayoutType == PageLayoutType.NewsDigest)
@@ -1844,8 +1864,8 @@ namespace PnP.Core.Model.SharePoint
             }
             else
             {
-                if (!string.IsNullOrWhiteSpace(pageHeaderHtml))
-                    PageListItem[PageConstants.PageLayoutContentField] = pageHeaderHtml;
+                if (pageHeader.Type == PageHeaderType.PageTitleWebPart)
+                    PageListItem[PageConstants.PageLayoutContentField] = SharePoint.PageHeader.PageTitleWebPartHeader();
 
                 // AuthorByline depends on a field holding the author values
                 var authorByLineIdField = PagesLibrary.Fields.AsRequested().FirstOrDefault(p => p.InternalName == PageConstants._AuthorByline);

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1646,8 +1646,12 @@ namespace PnP.Core.Model.SharePoint
             }
 
             var pageHeaderHtml = "";
+            var hasPageTitleWPInOneColumFullWith = false;
+            if (sections.Any() && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth && sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
+                hasPageTitleWPInOneColumFullWith = true; //Message ID: MC791596 / Roadmap ID: 386904
+
             if (pageHeader != null && pageHeader.Type != PageHeaderType.None && LayoutType != PageLayoutType.RepostPage
-                && LayoutType != PageLayoutType.Topic && LayoutType != PageLayoutType.NewsDigest)
+                && LayoutType != PageLayoutType.Topic && LayoutType != PageLayoutType.NewsDigest && !hasPageTitleWPInOneColumFullWith)
             {
                 // this triggers resolving of the header image which has to be done early as otherwise there will be version conflicts
                 // (see here: https://github.com/SharePoint/PnP-Sites-Core/issues/2203)
@@ -1840,7 +1844,8 @@ namespace PnP.Core.Model.SharePoint
             }
             else
             {
-                PageListItem[PageConstants.PageLayoutContentField] = pageHeaderHtml;
+                if (!string.IsNullOrWhiteSpace(pageHeaderHtml))
+                    PageListItem[PageConstants.PageLayoutContentField] = pageHeaderHtml;
 
                 // AuthorByline depends on a field holding the author values
                 var authorByLineIdField = PagesLibrary.Fields.AsRequested().FirstOrDefault(p => p.InternalName == PageConstants._AuthorByline);

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -2046,6 +2046,7 @@ namespace PnP.Core.Model.SharePoint
                 if (!PnPContext.Web.WebTemplate.Equals("SITEPAGEPUBLISHING", StringComparison.InvariantCultureIgnoreCase) &&
                     // we allow enabling communication site features on STS and EHS sites, so don't block adding full width sections on those sites
                     !PnPContext.Web.WebTemplate.Equals("STS", StringComparison.InvariantCultureIgnoreCase) &&
+                    !PnPContext.Web.WebTemplate.Equals("GROUP", StringComparison.InvariantCultureIgnoreCase) &&
                     !PnPContext.Web.WebTemplate.Equals("EHS", StringComparison.InvariantCultureIgnoreCase) &&
                     // SharePoint Syntex Content Center sites can also have full width sections
                     !PnPContext.Web.WebTemplate.Equals("CONTENTCTR", StringComparison.InvariantCultureIgnoreCase))

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
@@ -17,6 +17,7 @@ namespace PnP.Core.Model.SharePoint
         private const string NoPageHeader = "<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.4\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;instanceId&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;title&quot;&#58;&quot;Title Region&quot;,&quot;description&quot;&#58;&quot;Title Region Description&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.4&quot;,&quot;properties&quot;&#58;&#123;&quot;title&quot;&#58;&quot;@@title@@&quot;,&quot;imageSourceType&quot;&#58;4,&quot;layoutType&quot;&#58;&quot;NoImage&quot;,&quot;textAlignment&quot;&#58;&quot;@@textalignment@@&quot;,&quot;showTopicHeader&quot;&#58;@@showtopicheader@@,&quot;showPublishDate&quot;&#58;@@showpublishdate@@,&quot;topicHeader&quot;&#58;&quot;@@topicheader@@&quot;&#125;&#125;\"></div></div>";
         private const string DefaultPageHeader = "<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.4\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;instanceId&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;title&quot;&#58;&quot;Title Region&quot;,&quot;description&quot;&#58;&quot;Title Region Description&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&#125;,&quot;links&quot;&#58;&#123;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.4&quot;,&quot;properties&quot;&#58;&#123;&quot;title&quot;&#58;&quot;@@title@@&quot;,&quot;imageSourceType&quot;&#58;4,&quot;layoutType&quot;&#58;&quot;@@layouttype@@&quot;,&quot;textAlignment&quot;&#58;&quot;@@textalignment@@&quot;,&quot;showTopicHeader&quot;&#58;@@showtopicheader@@,&quot;showPublishDate&quot;&#58;@@showpublishdate@@,&quot;topicHeader&quot;&#58;&quot;@@topicheader@@&quot;,&quot;authorByline&quot;&#58;[@@authorbyline@@],&quot;authors&quot;&#58;[@@authors@@]&#125;&#125;\"></div></div>";
         private const string CustomPageHeader = "<div><div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.4\" data-sp-controldata=\"&#123;&quot;id&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;instanceId&quot;&#58;&quot;cbe7b0a9-3504-44dd-a3a3-0e5cacd07788&quot;,&quot;title&quot;&#58;&quot;Title Region&quot;,&quot;description&quot;&#58;&quot;Title Region Description&quot;,&quot;serverProcessedContent&quot;&#58;&#123;&quot;htmlStrings&quot;&#58;&#123;&#125;,&quot;searchablePlainTexts&quot;&#58;&#123;&#125;,&quot;imageSources&quot;&#58;&#123;&quot;imageSource&quot;&#58;&quot;@@imageSource@@&quot;&#125;,&quot;links&quot;&#58;&#123;&#125;,&quot;customMetadata&quot;&#58;&#123;&quot;imageSource&quot;&#58;&#123;&quot;siteId&quot;&#58;&quot;@@siteId@@&quot;,&quot;webId&quot;&#58;&quot;@@webId@@&quot;,&quot;listId&quot;&#58;&quot;@@listId@@&quot;,&quot;uniqueId&quot;&#58;&quot;@@uniqueId@@&quot;&#125;&#125;&#125;,&quot;dataVersion&quot;&#58;&quot;1.4&quot;,&quot;properties&quot;&#58;&#123;&quot;title&quot;&#58;&quot;@@title@@&quot;,&quot;imageSourceType&quot;&#58;2,&quot;layoutType&quot;&#58;&quot;@@layouttype@@&quot;,&quot;textAlignment&quot;&#58;&quot;@@textalignment@@&quot;,&quot;showTopicHeader&quot;&#58;@@showtopicheader@@,&quot;showPublishDate&quot;&#58;@@showpublishdate@@,&quot;topicHeader&quot;&#58;&quot;@@topicheader@@&quot;,&quot;authorByline&quot;&#58;[@@authorbyline@@],&quot;authors&quot;&#58;[@@authors@@],&quot;altText&quot;&#58;&quot;@@alternativetext@@&quot;,&quot;webId&quot;&#58;&quot;@@webId@@&quot;,&quot;siteId&quot;&#58;&quot;@@siteId@@&quot;,&quot;listId&quot;&#58;&quot;@@listId@@&quot;,&quot;uniqueId&quot;&#58;&quot;@@uniqueId@@&quot;@@focalPoints@@&#125;&#125;\"></div></div>";
+        private const string PageTitleWPHeader = "";
         private string imageServerRelativeUrl;
         private readonly PnPContext clientContext;
         private bool headerImageResolved;
@@ -164,6 +165,16 @@ namespace PnP.Core.Model.SharePoint
         {
             return NoHeader(pageTitle, PageHeaderTitleAlignment.Left);
         }
+
+        /// <summary>
+        ///  Returns the header value to set a "PageTitleWebPart"
+        /// </summary>
+        /// <returns></returns>
+        public static string PageTitleWebPartHeader()
+        {
+            return PageTitleWPHeader;
+        }
+
 
         /// <summary>
         /// Load the PageHeader object from the given html
@@ -348,6 +359,9 @@ namespace PnP.Core.Model.SharePoint
         /// <returns>Header html value</returns>
         public async Task<string> ToHtmlAsync(string pageTitle)
         {
+            if (Type == PageHeaderType.PageTitleWebPart)
+                return PageTitleWPHeader;
+
             if (pageTitle == null)
             {
                 pageTitle = "";

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -198,6 +198,10 @@ namespace PnP.Core.Model.SharePoint
             {
                 SupportsFullBleed = supportsFullBleed.GetBoolean();
             }
+            else if (Page.IdToDefaultWebPart(WebPartId) == DefaultWebPart.PageTitle)
+            {
+                SupportsFullBleed = true; //Message ID: MC791596 / Roadmap ID: 386904
+            }
             else
             {
                 SupportsFullBleed = false;
@@ -598,6 +602,8 @@ namespace PnP.Core.Model.SharePoint
             // Set property to trigger correct loading of properties 
             PropertiesJson = wpJObject.GetProperty("properties").ToString();
 
+            WebPartId = wpJObject.GetProperty("id").GetString();
+
             // Set/update dataVersion if it was set in the json data
             if (wpJObject.TryGetProperty("dataVersion", out JsonElement dataVersionValue))
             {
@@ -610,6 +616,10 @@ namespace PnP.Core.Model.SharePoint
                 if (properties.TryGetProperty("isFullWidth", out JsonElement isFullWidth))
                 {
                     SupportsFullBleed = isFullWidth.GetBoolean();
+                }
+                else if (Page.IdToDefaultWebPart(WebPartId) == DefaultWebPart.PageTitle)
+                {
+                    SupportsFullBleed = true; //Message ID: MC791596 / Roadmap ID: 386904
                 }
             }
 
@@ -628,8 +638,6 @@ namespace PnP.Core.Model.SharePoint
             {
                 DynamicDataValues = dynamicDataValues;
             }
-
-            WebPartId = wpJObject.GetProperty("id").GetString();
 
             if (wpDiv != null)
             {

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/Enums/PageHeaderType.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/Enums/PageHeaderType.cs
@@ -18,6 +18,11 @@
         /// <summary>
         /// The page use a customized header (e.g. with image + offset)
         /// </summary>
-        Custom = 2
+        Custom = 2,
+
+        /// <summary>
+        /// All Headersettings are in the PageTitle WebPart. PageTitle-WP in first section as OneColumnFullWith (Message ID: MC791596 / Roadmap ID: 386904)
+        /// </summary>
+        PageTitleWebPart = 3,
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/IPage.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/IPage.cs
@@ -246,6 +246,11 @@ namespace PnP.Core.Model.SharePoint
         public void SetCustomPageHeader(string serverRelativeImageUrl, double? translateX = null, double? translateY = null);
 
         /// <summary>
+        /// Sets page header back to the default for PageTilte WebPart (Message ID: MC791596 / Roadmap ID: 386904). The PageTitle WebPart has to be added into a first OneColumnFullWith Section separate.
+        /// </summary>
+        public void SetPageTitleWebPartPageHeader();
+
+        /// <summary>
         /// Adds a new header control to your client side page with a given order. Used for topic page creation
         /// </summary>
         /// <param name="control"><see cref="ICanvasControl"/> to add</param>


### PR DESCRIPTION
create from Blank Page in UI creates new format of Page-HTML because of MS Feature 386904.
All the settings from the Header DIV's have been moved to the WebPart-Settings of PageTitle WebPart.
The Manifest or settings of the PageTitle-WebPart do not reflect that it now should support fullbleed.
To dedect new Page-Format i go by the assumption that the PageTitle-WebPart needs to be placed in the first section which needs to be OneColumnFullWith.

With the code change i'm able to load and save a Page created from Blank-Page again:
```
                    var pages = await pnpContext.Web.GetPagesAsync("TestPageNew.aspx");
                    var testPage = pages.First();
                    await testPage.SaveAsync();
```

or create a new Page with same format like this:

```
                    var page = await pnpContext.Web.NewPageAsync();
                    page.AddSection(CanvasSectionTemplate.OneColumnFullWidth, 1);
                    page.AddSection(CanvasSectionTemplate.OneColumn, 2);
                    var availableComponents = await page.AvailablePageComponentsAsync();
                    var pageTitleWebPartComponent = availableComponents.FirstOrDefault(p => p.Id == page.DefaultWebPartToWebPartId(DefaultWebPart.PageTitle));
                    page.AddControl(page.NewWebPart(pageTitleWebPartComponent), page.Sections[0].Columns[0]);

                    var HeroWebPartComponent = availableComponents.FirstOrDefault(p => p.Id == page.DefaultWebPartToWebPartId(DefaultWebPart.Hero));
                    page.AddControl(page.NewWebPart(HeroWebPartComponent), page.Sections[1].Columns[0]);

                    await page.SaveAsync("TestFromCode.aspx");
```
