### PR TITLE
[Feature] add setting site logo support for group with applications perms

### DIFF
--- a/docs/using-the-sdk/branding-intro.md
+++ b/docs/using-the-sdk/branding-intro.md
@@ -114,9 +114,6 @@ await chrome.Header.ResetSiteLogoThumbnailAsync();
 
 While above methods work for any modern SharePoint site the implementation is different for group connected sites (such as a Team site) as for those sites the logo is maintained via the connected group. For group connected sites the site logo and the site logo thumbnail are the same and as such is does not matter which set or reset method you use, both result in the same code being called. Another difference is on how the provided image is stored: for group connected sites the image is stored with the Microsoft 365 group, whereas for other sites the image is first uploaded to the site assets library. Consequently there's also a difference in reset behavior: for group connected sites a reset will try to load the `__siteIcon__.jpg` file from the site assets library and set that as group image, for other site types there's no dependency on an image in site assets library.
 
-> [!Important]
-> When you're using the `SetSiteLogo` and `SetSiteLogoThumbnail` methods on a Microsoft 365 group connected site while using application permissions then you'll get an error. Currently these methods require delegated permissions when used on a group connected sites, usage on other sites is not impacted.
-
 ### Set and clear the header background image
 
 Whenever the site header layout is set to `Extended` you can optionally set a header background image via the `SetHeaderBackgroundImage` methods. Clearing the header background can be done using the `ClearHeaderBackgroundImage` methods.

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/AppManager.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/AppManager.cs
@@ -195,7 +195,7 @@ namespace PnP.Core.Admin.Model.SharePoint
             var apiCall = new ApiCall($"_api/web/{Scope}appcatalog/Add(overwrite={overwrite.ToString().ToLower()},url='{fileName}')", ApiType.SPORest)
             {
                 Interactive = true,
-                BinaryBody = fileBytes,
+                Content = new ByteArrayContent(fileBytes),
                 Headers = new Dictionary<string, string>()
             };
 

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/AttachmentCollection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/AttachmentCollection.cs
@@ -44,8 +44,9 @@ namespace PnP.Core.Model.SharePoint
             var api = new ApiCall(fileCreateRequest, ApiType.SPORest)
             {
                 Interactive = true,
-                BinaryBody = ToByteArray(content)
+                Content = new ByteArrayContent(ToByteArray(content))
             };
+
             await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
             return newFile;
         }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FieldThumbnailValue.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FieldThumbnailValue.cs
@@ -121,7 +121,7 @@ namespace PnP.Core.Model.SharePoint
             var api = new ApiCall(fileCreateRequest, ApiType.SPORest)
             {
                 Interactive = true,
-                BinaryBody = ToByteArray(content),
+                Content = new ByteArrayContent(ToByteArray(content))
             };
             
             var response = await (item as ListItem).RawRequestAsync(api, HttpMethod.Post).ConfigureAwait(false);

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FileCollection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FileCollection.cs
@@ -78,7 +78,7 @@ namespace PnP.Core.Model.SharePoint
             var api = new ApiCall(fileCreateRequest, ApiType.SPORest)
             {
                 Interactive = true,
-                BinaryBody = ToByteArray(content)
+                Content = new ByteArrayContent(ToByteArray(content))
             };
             await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
             return newFile;
@@ -122,7 +122,7 @@ namespace PnP.Core.Model.SharePoint
                     api = new ApiCall(endpointUrl, ApiType.SPORest)
                     {
                         Interactive = true,
-                        BinaryBody = chunk
+                        Content = new ByteArrayContent(chunk)
                     };
                     await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
                     firstChunk = false;
@@ -134,7 +134,7 @@ namespace PnP.Core.Model.SharePoint
                     var api = new ApiCall(endpointUrl, ApiType.SPORest)
                     {
                         Interactive = true,
-                        BinaryBody = chunk
+                        Content = new ByteArrayContent(chunk)
                     };
                     await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
 
@@ -146,7 +146,7 @@ namespace PnP.Core.Model.SharePoint
                     var api = new ApiCall(endpointUrl, ApiType.SPORest)
                     {
                         Interactive = true,
-                        BinaryBody = chunk
+                        Content = new ByteArrayContent(chunk)
                     };
                     await newFile.RequestAsync(api, HttpMethod.Post).ConfigureAwait(false);
                 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/UserProfile.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/UserProfile.cs
@@ -113,7 +113,7 @@ namespace PnP.Core.Model.SharePoint
             var apiCall = new ApiCall(baseUrl, ApiType.SPORest)
             {
                 Interactive = true,
-                BinaryBody = fileBytes
+                Content = new ByteArrayContent(fileBytes)
             };
 
             await RawRequestAsync(apiCall, HttpMethod.Post).ConfigureAwait(false);

--- a/src/sdk/PnP.Core/Services/Core/ApiCall.cs
+++ b/src/sdk/PnP.Core/Services/Core/ApiCall.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace PnP.Core.Services
 {
@@ -9,7 +10,8 @@ namespace PnP.Core.Services
     /// </summary>
     internal struct ApiCall
     {
-        internal ApiCall(string request, ApiType apiType, string jsonBody = null, string receivingProperty = null, bool loadPages = false)
+        internal ApiCall(string request, ApiType apiType, string jsonBody = null, string receivingProperty = null,
+            bool loadPages = false)
         {
             Type = apiType;
             Request = request;
@@ -22,7 +24,7 @@ namespace PnP.Core.Services
             RawResultsHandler = null;
             Commit = false;
             Interactive = false;
-            BinaryBody = null;
+            Content = null;
             ExpectBinaryResponse = false;
             StreamResponse = false;
             RemoveFromModel = false;
@@ -46,7 +48,7 @@ namespace PnP.Core.Services
             RawResultsHandler = null;
             Commit = false;
             Interactive = false;
-            BinaryBody = null;
+            Content = null;
             ExpectBinaryResponse = false;
             StreamResponse = false;
             RemoveFromModel = false;
@@ -117,9 +119,9 @@ namespace PnP.Core.Services
         internal bool Interactive { get; set; }
 
         /// <summary>
-        /// Binary content for this API call
+        /// Http Content to add Binary content or other content to this API call
         /// </summary>
-        internal byte[] BinaryBody { get; set; }
+        internal HttpContent Content { get; set; }
 
         /// <summary>
         /// Indicates whether the call expects a binary response

--- a/src/sdk/PnP.Core/Services/Core/Batch.cs
+++ b/src/sdk/PnP.Core/Services/Core/Batch.cs
@@ -251,7 +251,7 @@ namespace PnP.Core.Services
 
             lastBatchRequest.ApiCall = new ApiCall()
             {
-                BinaryBody = sourceApiCall.BinaryBody,
+                Content = sourceApiCall.Content,
                 Commit = sourceApiCall.Commit,
                 CSOMRequests = sourceApiCall.CSOMRequests,
                 ExecuteRequestApiCall = sourceApiCall.ExecuteRequestApiCall,

--- a/src/sdk/PnP.Core/Services/Core/BatchClient.cs
+++ b/src/sdk/PnP.Core/Services/Core/BatchClient.cs
@@ -995,10 +995,9 @@ namespace PnP.Core.Services
                         content.Headers.Add($"Content-Type", $"application/json");
                         PnPContext.Logger.LogDebug(requestBody);
                     }
-                    else if (graphRequest.ApiCall.BinaryBody != null)
+                    else if (graphRequest.ApiCall.Content != null)
                     {
-                        binaryContent = new ByteArrayContent(graphRequest.ApiCall.BinaryBody);
-                        request.Content = binaryContent;
+                        request.Content = graphRequest.ApiCall.Content;
                     }
 
                     // Add extra headers
@@ -1876,10 +1875,9 @@ namespace PnP.Core.Services
                         content.Headers.Add($"Content-Type", $"application/json;odata=verbose");
                         PnPContext.Logger.LogDebug(requestBody);
                     }
-                    else if (restRequest.ApiCall.BinaryBody != null)
+                    else if (restRequest.ApiCall.Content != null)
                     {
-                        binaryContent = new ByteArrayContent(restRequest.ApiCall.BinaryBody);
-                        request.Content = binaryContent;
+                        request.Content = restRequest.ApiCall.Content;
                     }
 
                     if (restRequest.ApiCall.ExpectBinaryResponse)


### PR DESCRIPTION
I changed the api call from SharePoint to the Graph api call so it is now possible to set the site logo of a group with application permission and still support it for delegated permissions.

Also I had to change the ApiCall.cs because you need to add the content-type to the ByteArrayContent for uploading the image to the Graph Api.