### PR TITLE
Fix check for HeaderTypes as new PageTitle WebPart in OneColumnFullWIth is not always in first section

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1445,8 +1445,7 @@ namespace PnP.Core.Model.SharePoint
             ReIndex();
 
             var hasPageTitleWPInOneColumFullWith = false;
-            if (sections.Count != 0 && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth &&
-                sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
+            if (sections.Any(s=> s.Type == CanvasSectionTemplate.OneColumnFullWidth && s.Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true)))
             {
                 hasPageTitleWPInOneColumFullWith = true; //Message ID: MC791596 / Roadmap ID: 386904
             }
@@ -1670,7 +1669,7 @@ namespace PnP.Core.Model.SharePoint
             var pageHeaderHtml = "";
             if (pageHeader != null)
             {
-                if(pageHeader.Type == PageHeaderType.Default && sections.Any() && sections.First().Type == CanvasSectionTemplate.OneColumnFullWidth && sections.First().Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true))
+                if(pageHeader.Type == PageHeaderType.Default && sections.Any(s=>s.Type == CanvasSectionTemplate.OneColumnFullWidth && s.Controls.Any(c => (c as PageWebPart)?.WebPartId?.Equals("cbe7b0a9-3504-44dd-a3a3-0e5cacd07788") == true)))
                 {
                     //Page created from code and Header was not set
                     SetPageTitleWebPartPageHeader();


### PR DESCRIPTION
The original fix was expecting the PageTitle WebPart to be the first in the first section which needs to be a OneColumnFullWith.
#1058
#1043

It seems that this assumption was wrong and it can be in any section. The check has been changed to reflect this.
There is a related fix for pnp.framework as the check is present there as well.