### PR TITLE
fix to #1553 if "_api/Web/SiteUsers" then the user is always added to the SiteUsers instead of the SPOGroup

### DIFF
--- a/src/sdk/PnP.Core/Model/Security/Internal/SharePointUser.cs
+++ b/src/sdk/PnP.Core/Model/Security/Internal/SharePointUser.cs
@@ -28,7 +28,7 @@ namespace PnP.Core.Model.Security
                         LoginName
                     };
                     var jsonBody = JsonSerializer.Serialize(body);
-                    return new ApiCall("_api/Web/SiteUsers", ApiType.SPORest, jsonBody);
+                    return new ApiCall(entity.SharePointGet, ApiType.SPORest, jsonBody);
 
                 }).ConfigureAwait(false);
             };


### PR DESCRIPTION
@jansenbe after the fix #1553 i was not able to add users to SharePoint Groups anymore. Output did show that await spGroup.AddUserAsync("i:0#.f|membership|xyz"); would send a post request to SiteUsers instead of the SPOGroup and therefore the user does not get added.