### PR TITLE
TenantProperties: AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled

### DIFF
--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/TenantProperties.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Internal/TenantProperties.cs
@@ -46,7 +46,9 @@ namespace PnP.Core.Admin.Model.SharePoint
         public IList<string> AllowSelectSecurityGroupsInSPSitesList { get => GetValue<IList<string>>(); set => SetValue(value); }
 
         public IList<string> AllowSelectSGsInODBListInTenant { get => GetValue<IList<string>>(); set => SetValue(value); }
-        
+
+        public bool AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled { get => GetValue<bool>(); set => SetValue(value); }
+
         public bool AnyoneLinkTrackUsers { get => GetValue<bool>(); set => SetValue(value); }
         
         public bool ApplyAppEnforcedRestrictionsToAdHocRecipients { get => GetValue<bool>(); set => SetValue(value); }

--- a/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/ITenantProperties.cs
+++ b/src/sdk/PnP.Core.Admin/Model/SharePoint/Core/Public/ITenantProperties.cs
@@ -79,6 +79,11 @@ namespace PnP.Core.Admin.Model.SharePoint
         bool AllowOverrideForBlockUserInfoVisibility { get; set; }
 
         /// <summary>
+        /// Gets or sets AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled value
+        /// </summary>
+        bool AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled { get; set; }
+
+        /// <summary>
         /// Gets or sets a value to handle guest sharing group's allow list
         /// </summary>
         IList<string> AllowSelectSecurityGroupsInSPSitesList { get; set; }


### PR DESCRIPTION
Add support to get/set AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled 

Tested as below
```
using var pnpContextAdminCenter = await pnpContext.GetSharePointAdmin().GetTenantAdminCenterContextAsync();
var tenantProperties = await pnpContextAdminCenter.GetSharePointAdmin().GetTenantPropertiesAsync();
tenantProperties.AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled=true;
await tenantProperties.UpdateAsync();
```