### PR TITLE
Feat: bump MSAL to the latest which is based on .NET 8

### DIFF
--- a/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
+++ b/src/sdk/PnP.Core.Auth/PnP.Core.Auth.csproj
@@ -47,7 +47,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.68.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
+++ b/src/sdk/PnP.Core.Test/PnP.Core.Test.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Identity.Client" Version="4.66.1" />
+		<PackageReference Include="Microsoft.Identity.Client" Version="4.68.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
 		<PackageReference Include="MSTest.TestAdapter" Version="3.6.3" />
 		<PackageReference Include="MSTest.TestFramework" Version="3.6.3" />


### PR DESCRIPTION
Bump MSAL to the latest one which is based on .NET 8