### PR TITLE
Adding validation if the If-Match is already present in a batch

### DIFF
--- a/src/sdk/PnP.Core/Services/Core/BatchClient.cs
+++ b/src/sdk/PnP.Core/Services/Core/BatchClient.cs
@@ -1541,7 +1541,10 @@ namespace PnP.Core.Services
                     {
                         sb.AppendLine($"{header.Key}: {header.Value}");
                     }
-                    sb.AppendLine($"X-HTTP-Method: DELETE");
+                    if (!headers.ContainsKey("X-HTTP-Method"))
+                    {
+                        sb.AppendLine($"X-HTTP-Method: DELETE");
+                    }                    
                     if (!headers.ContainsKey("IF-MATCH"))
                     {
                         sb.AppendLine($"IF-MATCH: *"); // TODO: Here we need the E-Tag or something to specify to use *

--- a/src/sdk/PnP.Core/Services/Core/BatchClient.cs
+++ b/src/sdk/PnP.Core/Services/Core/BatchClient.cs
@@ -1516,7 +1516,10 @@ namespace PnP.Core.Services
                     {
                         sb.AppendLine($"Content-Length: 0");
                     }
-                    sb.AppendLine($"If-Match: *"); // TODO: Here we need the E-Tag or something to specify to use *
+                    if (!headers.ContainsKey("IF-MATCH"))
+                    {                    
+                        sb.AppendLine($"If-Match: *"); // TODO: Here we need the E-Tag or something to specify to use *
+                    }
                     sb.AppendLine();
                     sb.AppendLine(requestBody);
                     sb.AppendLine();
@@ -1538,7 +1541,11 @@ namespace PnP.Core.Services
                     {
                         sb.AppendLine($"{header.Key}: {header.Value}");
                     }
-                    sb.AppendLine($"IF-MATCH: *"); // TODO: Here we need the E-Tag or something to specify to use *
+                    sb.AppendLine($"X-HTTP-Method: DELETE");
+                    if (!headers.ContainsKey("IF-MATCH"))
+                    {
+                        sb.AppendLine($"IF-MATCH: *"); // TODO: Here we need the E-Tag or something to specify to use *
+                    }                    
                     sb.AppendLine();
                     sb.AppendLine($"--changeset_{changesetId}--");
                 }


### PR DESCRIPTION
Adding validation if the If-Match was already passed in as a header to avoid conflicts

Fixes this issue:
https://github.com/pnp/powershell/issues/4837