### PR TITLE
Fix typo (hiarchy -> hierarchy)

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IFolder.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IFolder.cs
@@ -288,19 +288,19 @@ namespace PnP.Core.Model.SharePoint
        
         #region EnsureFolder
         /// <summary>
-        /// Ensures a (hiarchy) of folders exists on a given folder
+        /// Ensures a (hierarchy) of folders exists on a given folder
         /// </summary>
-        /// <param name="folderRelativeUrl">a (hiarchy) of folders (e.g. folderA/folderB/FolderC) </param>
+        /// <param name="folderRelativeUrl">a (hierarchy) of folders (e.g. folderA/folderB/FolderC) </param>
         /// <param name="expressions">Expressions needed to create the request, only used when the folder exists, if the returned folder was newly created the default properties are returned</param>
-        /// <returns>The <see cref="IFolder"/> representing the final folder in the hiarchy (e.g. FolderC)</returns>
+        /// <returns>The <see cref="IFolder"/> representing the final folder in the hierarchy (e.g. FolderC)</returns>
         public Task<IFolder> EnsureFolderAsync(string folderRelativeUrl, params Expression<Func<IFolder, object>>[] expressions);
 
         /// <summary>
-        /// Ensures a (hiarchy) of folders exists on a given folder
+        /// Ensures a (hierarchy) of folders exists on a given folder
         /// </summary>
-        /// <param name="folderRelativeUrl">a (hiarchy) of folders (e.g. folderA/folderB/FolderC) </param>
+        /// <param name="folderRelativeUrl">a (hierarchy) of folders (e.g. folderA/folderB/FolderC) </param>
         /// <param name="expressions">Expressions needed to create the request, only used when the folder exists, if the returned folder was newly created the default properties are returned</param>
-        /// <returns>The <see cref="IFolder"/> representing the final folder in the hiarchy (e.g. FolderC)</returns>
+        /// <returns>The <see cref="IFolder"/> representing the final folder in the hierarchy (e.g. FolderC)</returns>
         public IFolder EnsureFolder(string folderRelativeUrl, params Expression<Func<IFolder, object>>[] expressions);
         #endregion
 


### PR DESCRIPTION
The docs for iFolder class mistakenly treats `hierarchy` as `hiarchy`. This can make it difficult for users searching for `hierarchy` to find the right docs.