### PR TITLE
Feature/allow optional configuration of SharePointRestClient and MicrosoftGraphClient

### DIFF
--- a/src/sdk/PnP.Core/Services/Builder/PnPCoreServiceCollectionExtensions.cs
+++ b/src/sdk/PnP.Core/Services/Builder/PnPCoreServiceCollectionExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// Optional additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
         /// </para>
         /// </remarks>
         /// <param name="services">The collection of services in an <see cref="IServiceCollection" /></param>
@@ -34,7 +34,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// Optional additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
         /// </para>
         /// </remarks>
         /// <param name="services">The collection of services in an <see cref="IServiceCollection" /></param>

--- a/src/sdk/PnP.Core/Services/Builder/PnPCoreServiceCollectionExtensions.cs
+++ b/src/sdk/PnP.Core/Services/Builder/PnPCoreServiceCollectionExtensions.cs
@@ -13,21 +13,39 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <summary>
         /// Configures PnP Core SDK with default options
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// </para>
+        /// </remarks>
         /// <param name="services">The collection of services in an <see cref="IServiceCollection" /></param>
+        /// <param name="configureSharePointRest">additional configuration to <see cref="SharePointRestClient"/></param>
+        /// <param name="configureMicrosoftGraph">additional configuration to <see cref="MicrosoftGraphClient"/></param>
         /// <returns>A PnPCoreBuilder instance</returns>
-        public static IPnPCoreBuilder AddPnPCore(this IServiceCollection services)
+        public static IPnPCoreBuilder AddPnPCore(this IServiceCollection services,
+            Action<IHttpClientBuilder> configureSharePointRest = null,
+            Action<IHttpClientBuilder> configureMicrosoftGraph = null)
         {
-            return AddPnPCore(services, null);
+            return AddPnPCore(services, null, configureSharePointRest, configureMicrosoftGraph);
         }
 
         /// <summary>
         /// Configures PnP Core SDK with custom options
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// </para>
+        /// </remarks>
         /// <param name="services">The collection of services in an <see cref="IServiceCollection" /></param>
         /// <param name="options">An Action to configure the PnP Core options</param>
+        /// <param name="configureSharePointRest">additional configuration to <see cref="SharePointRestClient"/></param>
+        /// <param name="configureMicrosoftGraph">additional configuration to <see cref="MicrosoftGraphClient"/></param>
         /// <returns>A PnPCoreBuilder instance</returns>
         public static IPnPCoreBuilder AddPnPCore(this IServiceCollection services,
-            Action<PnPCoreOptions> options)
+            Action<PnPCoreOptions> options,
+            Action<IHttpClientBuilder> configureSharePointRest = null,
+            Action<IHttpClientBuilder> configureMicrosoftGraph = null)
         {
             if (services == null)
             {
@@ -40,7 +58,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.ConfigureOptions<PnPCoreOptionsConfigurator>();
-            services.AddPnPContextFactory();
+            services.AddPnPContextFactory(configureSharePointRest, configureMicrosoftGraph);
 
             return new PnPCoreBuilder(services);
         }

--- a/src/sdk/PnP.Core/Services/Core/PnPContextFactoryCollectionExtensions.cs
+++ b/src/sdk/PnP.Core/Services/Core/PnPContextFactoryCollectionExtensions.cs
@@ -19,7 +19,7 @@ namespace PnP.Core.Services
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// Optional additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
         /// </para>
         /// </remarks>
         /// <param name="collection">Collection of loaded services</param>
@@ -47,7 +47,7 @@ namespace PnP.Core.Services
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// Optional additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
         /// </para>
         /// </remarks>
         /// <param name="collection">Collection of loaded services</param>
@@ -134,7 +134,6 @@ namespace PnP.Core.Services
                 });
             microsoftGraphBuilder = collection.AddHttpClient<MicrosoftGraphClient>()
                 .AddHttpMessageHandler<MicrosoftGraphRetryHandler>()
-                .
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                 {
                     AutomaticDecompression = DecompressionMethods.GZip

--- a/src/sdk/PnP.Core/Services/Core/PnPContextFactoryCollectionExtensions.cs
+++ b/src/sdk/PnP.Core/Services/Core/PnPContextFactoryCollectionExtensions.cs
@@ -17,9 +17,18 @@ namespace PnP.Core.Services
         /// <summary>
         /// Adds the <see cref="PnPContextFactory"/> to the collection of services
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// </para>
+        /// </remarks>
         /// <param name="collection">Collection of loaded services</param>
+        /// <param name="configureSharePointRest">additional configuration to <see cref="SharePointRestClient"/></param>
+        /// <param name="configureMicrosoftGraph">additional configuration to <see cref="MicrosoftGraphClient"/></param>
         /// <returns>Collection of loaded services</returns>
-        public static IServiceCollection AddPnPContextFactory(this IServiceCollection collection)
+        public static IServiceCollection AddPnPContextFactory(this IServiceCollection collection,
+            Action<IHttpClientBuilder> configureSharePointRest = null,
+            Action<IHttpClientBuilder> configureMicrosoftGraph = null)
         {
             if (collection == null)
             {
@@ -29,17 +38,28 @@ namespace PnP.Core.Services
             // Add a SharePoint Online Context Factory service instance
             return collection
                 .AddHttpHandlers()
-                .AddHttpClients()
+                .AddHttpClients(configureSharePointRest, configureMicrosoftGraph)
                 .AddPnPServices();
         }
 
         /// <summary>
-        /// Adds the <see cref="PnPContextFactory"/> to the collection of services with options
+        /// Adds the <see cref="PnPContextFactory"/> to the collection of services with options. 
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Optionally additional configuration can be provided for <see cref="SharePointRestClient"/> and/or <see cref="MicrosoftGraphClient"/>
+        /// </para>
+        /// </remarks>
         /// <param name="collection">Collection of loaded services</param>
         /// <param name="options"><see cref="PnPContextFactory"/> configuration options</param>
+        /// <param name="configureSharePointRest">additional configuration to <see cref="SharePointRestClient"/></param>
+        /// <param name="configureMicrosoftGraph">additional configuration to <see cref="MicrosoftGraphClient"/></param>
         /// <returns>Collection of loaded services</returns>
-        public static IServiceCollection AddPnPContextFactory(this IServiceCollection collection, Action<PnPContextFactoryOptions> options)
+        public static IServiceCollection AddPnPContextFactory(
+            this IServiceCollection collection,
+            Action<PnPContextFactoryOptions> options,
+            Action<IHttpClientBuilder> configureSharePointRest = null,
+            Action<IHttpClientBuilder> configureMicrosoftGraph = null)
         {
             if (collection == null)
             {
@@ -55,7 +75,7 @@ namespace PnP.Core.Services
             // Add a PnP Context Factory service instance
             return collection
                 .AddHttpHandlers()
-                .AddHttpClients()
+                .AddHttpClients(configureSharePointRest, configureMicrosoftGraph)
                 .AddPnPServices();
         }
 
@@ -69,19 +89,22 @@ namespace PnP.Core.Services
             return collection;
         }
 
-        private static IServiceCollection AddHttpClients(this IServiceCollection collection)
+        private static IServiceCollection AddHttpClients(this IServiceCollection collection, Action<IHttpClientBuilder> configureSharePointRest = null, Action<IHttpClientBuilder> configureMicrosoftGraph = null)
         {
+            IHttpClientBuilder sharePointRestBuilder;
+            IHttpClientBuilder microsoftGraphBuilder;
+
 #if NET5_0_OR_GREATER
             if (RuntimeInformation.RuntimeIdentifier == "browser-wasm")
             {
-                collection.AddHttpClient<SharePointRestClient>()
+                sharePointRestBuilder = collection.AddHttpClient<SharePointRestClient>()
                     .AddHttpMessageHandler<SharePointRestRetryHandler>();
-                collection.AddHttpClient<MicrosoftGraphClient>()
+                microsoftGraphBuilder = collection.AddHttpClient<MicrosoftGraphClient>()
                     .AddHttpMessageHandler<MicrosoftGraphRetryHandler>();
             }
             else
             {
-                collection.AddHttpClient<SharePointRestClient>()
+                sharePointRestBuilder = collection.AddHttpClient<SharePointRestClient>()
                     .AddHttpMessageHandler<SharePointRestRetryHandler>()
                     // We use cookies by adding them to the header which works great when used from Core framework,
                     // however when running the .NET Standard 2.0 version from .NET Framework we explicetely have to
@@ -91,7 +114,7 @@ namespace PnP.Core.Services
                         UseCookies = false,
                         AutomaticDecompression = DecompressionMethods.All
                     });
-                collection.AddHttpClient<MicrosoftGraphClient>()
+                microsoftGraphBuilder = collection.AddHttpClient<MicrosoftGraphClient>()
                     .AddHttpMessageHandler<MicrosoftGraphRetryHandler>()
                     .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                     {
@@ -99,7 +122,7 @@ namespace PnP.Core.Services
                     });
             }
 #else
-            collection.AddHttpClient<SharePointRestClient>()
+            sharePointRestBuilder = collection.AddHttpClient<SharePointRestClient>()
                 .AddHttpMessageHandler<SharePointRestRetryHandler>()
                 // We use cookies by adding them to the header which works great when used from Core framework,
                 // however when running the .NET Standard 2.0 version from .NET Framework we explicetely have to
@@ -109,13 +132,17 @@ namespace PnP.Core.Services
                     UseCookies = false,
                     AutomaticDecompression = DecompressionMethods.GZip
                 });
-            collection.AddHttpClient<MicrosoftGraphClient>()
+            microsoftGraphBuilder = collection.AddHttpClient<MicrosoftGraphClient>()
                 .AddHttpMessageHandler<MicrosoftGraphRetryHandler>()
+                .
                 .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
                 {
                     AutomaticDecompression = DecompressionMethods.GZip
                 });
 #endif
+            configureSharePointRest?.Invoke(sharePointRestBuilder);
+            configureMicrosoftGraph?.Invoke(microsoftGraphBuilder);
+
             return collection;
         }
 


### PR DESCRIPTION
added optional configuration to be applied to SharePointRestClient and MicrosoftGraphClient. This will allow delegating handlers from a consumer of this SDK to be applied to either or both clients