### PR TITLE
fix: map dublin timezone correctly

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/TimeZone.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/TimeZone.cs
@@ -64,7 +64,7 @@ namespace PnP.Core.Model.SharePoint
         {
             var timeZoneInfo = timeZoneId switch
             {
-                2 => TZConvert.GetTimeZoneInfo("UTC"), // (UTC) Dublin, Edinburgh, Lisbon, London
+                2 => TZConvert.GetTimeZoneInfo("GMT Standard Time"), // (UTC) Dublin, Edinburgh, Lisbon, London
                 3 => TZConvert.GetTimeZoneInfo("Romance Standard Time"), // (UTC+01:00) Brussels, Copenhagen, Madrid, Paris
                 4 => TZConvert.GetTimeZoneInfo("W. Europe Standard Time"), // (UTC+01:00) Amsterdam, Berlin, Bern, Rome, Stockholm, Vienna
                 5 => TZConvert.GetTimeZoneInfo("GTB Standard Time"), // (UTC+02:00) Athens, Bucharest


### PR DESCRIPTION
Fixes #1664

When a SharePoint site has the `TimeZone` set to `(UTC) Dublin, Edinburg, Lisbon, London`, `PnP.Core` incorrectly maps this to `UTC`. Thereby, it does not take into account daylight savings when creating posts to the API.

This PR fixes that by changing `id: 2, (UTC) Dublin, Edinburg, Lisbon, London` to map to `GMT Standard Time`

## Explanation 
In `ListItem.cs`:

https://github.com/pnp/pnpcore/blob/a0d5c94d4c4110663830e5cd6671c571ce4c6c08/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs#L706C1-L716C10

_Assumptions_: In the current code implementation, all dates are converted to the local datetimes of the SharePoint site. I haven't been able to test whether or not this is because that the SharePoint REST API does not support the ISO 8601 format, but I'd suggest moving to that format if possible.

The code converts the local DateTime to a UTC DateTime. 

Before posting to SharePoint, however, the UTC DateTime must be converted to that specific site current DateTime, taking into account any daylight savings and other biases. 

It uses the internal class, `TimeZone.cs` to do this. However, the fault lies in `GetTimeZoneInfoFromSharePoint`.

Here, it wrongly assumes that the timezone `id: 2, (UTC) Dublin, Edinburg, Lisbon, London` maps to `UTC` in the `TZConvert` library. However, this assumption is wrong. The timezone should be `GMT Standard Time` as can be seen in the `TZConvert` Unicode Common Locale Data Repository (Search for Dublin):

https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml

If users wish this timezone, they should use the SharePoint Regional Setting: `id: 93, (UTC) Coordinated Universal Time` instead

## Unit tests
Unit tests passes with the CI configuration.
