### PR TITLE
Add DeviceCodeVerification Property to Credential Initialization

### DIFF
--- a/src/sdk/PnP.Core.Auth/Public/DeviceCodeAuthenticationProvider.cs
+++ b/src/sdk/PnP.Core.Auth/Public/DeviceCodeAuthenticationProvider.cs
@@ -116,6 +116,12 @@ namespace PnP.Core.Auth
                 .WithHttpClientFactory(msalHttpClientFactory)
                 .Build();
 
+            // DeviceCodeVerification を options からセット
+            if (options.DeviceCodeVerification != null)
+            {
+                DeviceCodeVerification = options.DeviceCodeVerification;
+            }
+
             // Log the initialization information
             Log?.LogInformation(PnPCoreAuthResources.DeviceCodeAuthenticationProvider_LogInit);
         }

--- a/src/sdk/PnP.Core.Auth/Services/Builder/Configuration/PnPCoreAuthenticationOptions.cs
+++ b/src/sdk/PnP.Core.Auth/Services/Builder/Configuration/PnPCoreAuthenticationOptions.cs
@@ -78,6 +78,10 @@ namespace PnP.Core.Auth.Services.Builder.Configuration
     public class PnPCoreAuthenticationCredentialConfigurationOptions
     {
         /// <summary>
+        /// Action to notify the end user about the device code request
+        /// </summary>
+        public Action<DeviceCodeNotification> DeviceCodeVerification { get; set; }
+        /// <summary>
         /// The ClientId of the application to use for authentication
         /// </summary>
         public string ClientId { get; set; }


### PR DESCRIPTION
This pull request introduces a new feature to the `PnP.Core.Auth` library by adding support for a `DeviceCodeVerification` action, which allows notifying the end user about the device code request during authentication. The most important changes include updating the `DeviceCodeAuthenticationProvider` to use this new option and adding the `DeviceCodeVerification` property to the `PnPCoreAuthenticationCredentialConfigurationOptions` class.

### New Feature: Device Code Verification Support

* **`DeviceCodeAuthenticationProvider` initialization update**: Added logic to set the `DeviceCodeVerification` property from the `options` parameter during initialization. This ensures that the device code notification action is properly configured if provided. (`src/sdk/PnP.Core.Auth/Public/DeviceCodeAuthenticationProvider.cs`, [src/sdk/PnP.Core.Auth/Public/DeviceCodeAuthenticationProvider.csR119-R124](diffhunk://#diff-8e402a7b59e6e7bad0c697723689a17f4b2793c70c006fde60c0634162846658R119-R124))
* **New `DeviceCodeVerification` property**: Introduced a new `DeviceCodeVerification` property in the `PnPCoreAuthenticationCredentialConfigurationOptions` class. This property is an `Action<DeviceCodeNotification>` that allows developers to define a custom action to notify users about the device code request. (`src/sdk/PnP.Core.Auth/Services/Builder/Configuration/PnPCoreAuthenticationOptions.cs`, [src/sdk/PnP.Core.Auth/Services/Builder/Configuration/PnPCoreAuthenticationOptions.csR80-R83](diffhunk://#diff-f1056d0e486c8564ae8d1dcf2c9366a228f60be1c2de6b95dffa519125bf5310R80-R83))