### PR TITLE
Escape JSON from the Property value

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -672,18 +672,31 @@ namespace PnP.Core.Model.SharePoint
         private static string EscapeJsonValues(string decodedWebPart)
         {
             // regular expression to find a JSON string value (property with html content example: data-config-json=\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\" )
-            System.Text.RegularExpressions.Regex regex = new(@"\\""{("".+?)}\\""", System.Text.RegularExpressions.RegexOptions.Singleline);
+            System.Text.RegularExpressions.Regex regex = new(@"\\""({"".+?})\\""", System.Text.RegularExpressions.RegexOptions.Singleline);
             // get all matches
             System.Text.RegularExpressions.MatchCollection matches = regex.Matches(decodedWebPart);
-            // iterate over all matches
             if (matches.Count > 0)
             {
+                string jsonSnippet = string.Empty;
+                // iterate over all matches
                 foreach (System.Text.RegularExpressions.Match match in matches)
                 {
+                    jsonSnippet = match.Groups[1].Value;
+                    // Try to parse the JSON to see if it's valid
+                    try
+                    {
+                        _ = JsonDocument.Parse(jsonSnippet); // success = unescaped
+                    }
+                    catch
+                    {
+                        // Already escaped or malformed – don't re-escape
+                        continue;
+                    }
+
                     // replace all double quotes with escaped double quotes
-                    var escapedMatch = match.Groups[1].Value.Replace("\"", "\\\"");
+                    var escapedSnipped = jsonSnippet.Replace("\"", "\\\"");
                     // replace the original match with the escaped match
-                    decodedWebPart = decodedWebPart.Replace(match.Groups[1].Value, escapedMatch);
+                    decodedWebPart = decodedWebPart.Replace(jsonSnippet, escapedSnipped);
                 }
             }
 

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -573,6 +573,8 @@ namespace PnP.Core.Model.SharePoint
                 return;
             }
 
+            decodedWebPart = EscapeJsonValues(decodedWebPart);
+
             if (!SafeDeserializeDecoded(decodedWebPart, out var wpJObject))
             {
                 Title = "Failed to deserialize WebPart";
@@ -660,6 +662,32 @@ namespace PnP.Core.Model.SharePoint
             {
                 ACECardSize = ACECardSizeElement.GetString();
             }
+        }
+
+        /// <summary>
+        /// Escape JSON from the Property value
+        /// </summary>
+        /// <param name="decodedWebPart"></param>
+        /// <returns></returns>
+        private static string EscapeJsonValues(string decodedWebPart)
+        {
+            // regular expression to find a JSON string value (property with html content example: data-config-json=\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\" )
+            System.Text.RegularExpressions.Regex regex = new(@"\\""{("".+?)}\\""", System.Text.RegularExpressions.RegexOptions.Singleline);
+            // get all matches
+            System.Text.RegularExpressions.MatchCollection matches = regex.Matches(decodedWebPart);
+            // iterate over all matches
+            if (matches.Count > 0)
+            {
+                foreach (System.Text.RegularExpressions.Match match in matches)
+                {
+                    // replace all double quotes with escaped double quotes
+                    var escapedMatch = match.Groups[1].Value.Replace("\"", "\\\"");
+                    // replace the original match with the escaped match
+                    decodedWebPart = decodedWebPart.Replace(match.Groups[1].Value, escapedMatch);
+                }
+            }
+
+            return decodedWebPart;
         }
 
         private static bool SafeDeserializeDecoded(string decodedWebPart, out JsonElement wpJObject)


### PR DESCRIPTION
Fix issue `'a' is invalid after a value. Expected either ',', '}', or ']'`

This fix is to find and escape a JSON string value inside a property with HTML content with data attributes with JSON

example: 
escape JSON snippet: { "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] } from "TemplateHtml": ".... class=\\"portal-search-page\\" data-config-json=\\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\\" ) ...