### PR TITLE
#1499 can load and save pages without loosing empty sections.

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasColumn.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasColumn.cs
@@ -162,28 +162,9 @@ namespace PnP.Core.Model.SharePoint
             // if a section does not contain a control we still need to render it, otherwise it get's "lost"
             if (!controlWrittenToSection)
             {
-                // Obtain the json data
-                var clientSideCanvasPosition = new CanvasData()
-                {
-                    Position = new CanvasPosition()
-                    {
-                        ZoneIndex = Section.Order,
-                        SectionIndex = Order,
-                        SectionFactor = ColumnFactor,
-                        LayoutIndex = LayoutIndex,
-                        ZoneId = ZoneId,
-                        IsLayoutReflowOnTop = IsLayoutReflowOnTop,
-                    },
-
-                    Emphasis = new SectionEmphasis()
-                    {
-                        ZoneEmphasis = VerticalSectionEmphasis ?? Section.ZoneEmphasis,
-                    }
-                };
-
-                var jsonControlData = JsonSerializer.Serialize(clientSideCanvasPosition);
-
-                html.Append($@"<div {CanvasControlAttribute}="""" {CanvasDataVersionAttribute}=""{DataVersion}"" {ControlDataAttribute}=""{jsonControlData.Replace("\"", "&quot;")}""></div>");
+                var emptySection = new EmptySection(Section, this);
+                controlIndex++;
+                html.Append(emptySection.ToHtml(controlIndex));
             }
 
             return html.ToString();

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasControl.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/CanvasControl.cs
@@ -346,6 +346,10 @@ namespace PnP.Core.Model.SharePoint
             {
                 return typeof(SectionBackgroundControl);
             }
+            else if (controlData.ControlType == 1)
+            {
+                return typeof(EmptySection); // Special Control Type used if no WebPart is in Section
+            }
 
             return null;
         }
@@ -360,7 +364,15 @@ namespace PnP.Core.Model.SharePoint
             canvasDataVersion = element.GetAttribute(CanvasDataVersionAttribute);
             canvasControlData = element.GetAttribute(CanvasControlAttribute);
             controlType = controlData.ControlType;
-            instanceId = new Guid(controlData.Id ?? Guid.NewGuid().ToString());
+            if (Guid.TryParse(controlData.Id, out var controlId))
+            {
+                instanceId = controlId;
+            }
+            else
+            {
+                // If the Id is not a valid Guid, generate a new one - but need to be carefull as emptySection has Id = "emptySection"
+                instanceId = Guid.NewGuid();
+            }
         }
 
         internal void MoveTo(ICanvasSection newSection, ICanvasColumn newColumn)

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/EmptySection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/EmptySection.cs
@@ -12,9 +12,14 @@ namespace PnP.Core.Model.SharePoint
     {
         public EmptySection() : base()
         {
-            var emptyJson = JsonSerializer.Deserialize<JsonElement>("{}");
-
             controlType = 1; // emptySection
+        }
+
+        public EmptySection(ICanvasSection Section, ICanvasColumn Column) : base()
+        {
+            controlType = 1; // emptySection
+            section = Section;
+            column = Column;
         }
 
         /// <summary>

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/EmptySection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/EmptySection.cs
@@ -1,0 +1,100 @@
+﻿using AngleSharp.Dom;
+using System;
+using System.Text;
+using System.Text.Json;
+
+namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// This class is used to instantiate controls of type 1 (= emptySection).
+    /// </summary>
+    internal sealed class EmptySection : CanvasControl, IEmptySection
+    {
+        public EmptySection() : base()
+        {
+            var emptyJson = JsonSerializer.Deserialize<JsonElement>("{}");
+
+            controlType = 1; // emptySection
+        }
+
+        /// <summary>
+        /// Return <see cref="Type"/> of the client side web part
+        /// </summary>
+        public override Type Type
+        {
+            get
+            {
+                return typeof(EmptySection);
+            }
+        }
+
+        /// <summary>
+        /// Deserialized value of the "data-sp-controldata" attribute
+        /// </summary>
+        internal CanvasControlData SpControlData { get; private set; }
+
+        #region public methods
+        public override string ToHtml(float controlIndex)
+        {
+            CanvasControlData controlData = new CanvasControlData
+            {
+                ControlType = ControlType,
+                Id = "emptySection",//for other webParts this is a Guid but here it seems to be a static value 
+                Position = new CanvasControlPosition()
+                {
+                    ZoneIndex = Section.Order,
+                    SectionIndex = Column.Order,
+                    SectionFactor = Column.ColumnFactor,
+                    LayoutIndex = Column.LayoutIndex,
+                    ControlIndex = controlIndex,
+                    ZoneId = column.ZoneId,
+                    IsLayoutReflowOnTop = Column.IsLayoutReflowOnTop
+                },
+                Emphasis = new SectionEmphasis()
+                {
+                    ZoneEmphasis = Column.VerticalSectionEmphasis ?? Section.ZoneEmphasis,
+                }
+            };
+
+            // Persist the collapsible section settings
+            if (Section.Collapsible && !Column.IsVerticalSectionColumn)
+            {
+                controlData.ZoneGroupMetadata = new SectionZoneGroupMetadata()
+                {
+                    // Set section type to 1 if it was not set (when new sections are added via code)
+                    Type = (Section as CanvasSection).SectionType == 0 ? 1 : (Section as CanvasSection).SectionType,
+                    DisplayName = Section.DisplayName,
+                    IsExpanded = Section.IsExpanded,
+                    ShowDividerLine = Section.ShowDividerLine,
+                };
+
+                if (Section.IconAlignment.HasValue)
+                {
+                    controlData.ZoneGroupMetadata.IconAlignment = Section.IconAlignment.Value.ToString().ToLower();
+                }
+                else
+                {
+                    controlData.ZoneGroupMetadata.IconAlignment = "true";
+                }
+            }
+
+            jsonControlData = JsonSerializer.Serialize(controlData);
+
+            StringBuilder html = new StringBuilder();
+            html.Append($@"<div {CanvasControlAttribute}=""{CanvasControlData}"" {CanvasDataVersionAttribute}=""{DataVersion}""  {ControlDataAttribute}=""{jsonControlData.Replace("\"", "&quot;")}"">");
+            html.Append("</div>");
+            return html.ToString();
+        }
+        #endregion
+
+        #region Internal and private methods
+        internal override void FromHtml(IElement element, bool isHeader)
+        {
+            base.FromHtml(element, isHeader);
+            SpControlData = JsonSerializer.Deserialize<TextControlData>(element.GetAttribute(ControlDataAttribute), PnPConstants.JsonSerializer_IgnoreNullValues);
+            controlType = SpControlData.ControlType;
+        }
+        #endregion
+
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1242,7 +1242,6 @@ namespace PnP.Core.Model.SharePoint
                         var control = new SectionBackgroundControl
                         {
                             Order = controlOrder 
-
                         };
                         control.FromHtml(clientSideControl, false);
 
@@ -1251,7 +1250,19 @@ namespace PnP.Core.Model.SharePoint
 
                         AddControl(control);
                     }
+                    else if (controlType ==typeof(EmptySection))
+                    {
+                        var control = new EmptySection
+                        {
+                            Order = controlOrder
+                        };
+                        control.FromHtml(clientSideControl, false);
 
+                        // Handle control positioning in sections and columns
+                        ApplySectionAndColumn(control, control.SpControlData.Position, control.SpControlData.Emphasis, control.SpControlData.ZoneGroupMetadata);
+
+                        AddControl(control);
+                    }
                     else if (controlType == typeof(CanvasColumn))
                     {
                         // Need to parse empty sections

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/SectionZoneGroupMetadata.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/SectionZoneGroupMetadata.cs
@@ -34,5 +34,12 @@ namespace PnP.Core.Model.SharePoint
         {
             get; set;
         }
+
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("isTitleEnabled")]
+        public bool? IsTitleEnabled
+        {
+            get; set;
+        }
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/IEmptySection.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Public/IEmptySection.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// This class is used to instantiate controls of type 1 (= emptySection).
+    /// </summary>
+    public interface IEmptySection : ICanvasControl
+    {
+
+        /// <summary>
+        /// Type of the control (= <see cref="IEmptySection"/>)
+        /// </summary>
+        public new Type Type { get; }
+    }
+}


### PR DESCRIPTION
Empty Sections use a special ControlType to save the settings:

{
	"position": {
		"layoutIndex": 1,
		"zoneIndex": 2,
		"zoneId": "7cac6f3c-c012-47a4-89ab-cbe3611349d5",
		"sectionIndex": 1,
		"sectionFactor": 6,
		"controlIndex": 1
	},
	"emphasis": {
		"zoneEmphasis": 2
	},
	"zoneGroupMetadata": {
		"type": 1,
		"isExpanded": false,
		"showDividerLine": false,
		"iconAlignment": "right",
		"isTitleEnabled": false
	},
	"id": "emptySection",
	"controlType": 1,
	"addedFromPersistedData": true
}

 Contains also support for isTitleEnabled. 