### PR TITLE
Fix #1656: IList.ReIndexAsync() has no effect.

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/List.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/List.cs
@@ -1666,6 +1666,9 @@ namespace PnP.Core.Model.SharePoint
             listInfo.RootFolder.Properties.Values[reIndexKey] = searchVersion + 1;
 
             await listInfo.RootFolder.Properties.UpdateAsync().ConfigureAwait(false);
+
+            // Updating the list is required, otherwise the re-indexing of the list doesn't start (fixes issue 1656).
+            await listInfo.UpdateAsync().ConfigureAwait(false);
         }
 
         public void ReIndex()


### PR DESCRIPTION
As described in the issue #1656, an `Update()` is required on the list in addition to the `Update()` of the property bag of the list's root folder so the indexing of the list ist properly triggered.

Countrary to the PnP PowerShell Cmdlet `Request-PnPReIndexList`, which is using SharePoint CSOM internally, I have not batched the two Update() statements in a single request, as the method `IPropertyValues.UpdateAsync()` doesn't have a `-Batch` variant.