### PR TITLE
fix pnp.core Header-Type to Custom when LayoutType NoImage

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
@@ -344,7 +344,14 @@ namespace PnP.Core.Model.SharePoint
                             }
                             else
                             {
-                                Type = PageHeaderType.Default;
+                                if (LayoutType == PageHeaderLayoutType.NoImage)
+                                {
+                                    Type = PageHeaderType.Custom;
+                                }
+                                else
+                                {
+                                    Type = PageHeaderType.Default;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
#1640 this fix does maintain NoImage / Custom Header inside pnp.core when load page and SaveAs to different file or when create page from code for example like this: 

```
  var newPage = await pnpContext.Web.NewPageAsync();
  newPage.PageHeader.LayoutType = PageHeaderLayoutType.NoImage;
  newPage.AddSection(CanvasSectionTemplate.OneColumnVerticalSection, 1);
  newPage.Sections[0].ZoneEmphasis = 1;
  newPage.AddSection(CanvasSectionTemplate.OneColumn, 2);
  newPage.Sections[1].ZoneEmphasis = 2;
  var ok=await newPage.SaveAsync("TestPage-NoImage.aspx");
```

The Export-/Apply-Template issue needs a separate fix in pnp-framework