### PR TITLE
Improve validation to escape double quotes for any string inside html property=\"...\"

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -671,32 +671,29 @@ namespace PnP.Core.Model.SharePoint
         /// <returns></returns>
         private static string EscapeJsonValues(string decodedWebPart)
         {
-            // regular expression to find a JSON string value (property with html content example: data-config-json=\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\" )
-            System.Text.RegularExpressions.Regex regex = new(@"\\""({"".+?})\\""", System.Text.RegularExpressions.RegexOptions.Singleline);
+            // regular expression to find a unescaped string value (property with html content example: data-config-json=\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\" )
+            System.Text.RegularExpressions.Regex regex = new(@"\\""(.*?)\\""", System.Text.RegularExpressions.RegexOptions.Singleline);
             // get all matches
             System.Text.RegularExpressions.MatchCollection matches = regex.Matches(decodedWebPart);
             if (matches.Count > 0)
             {
-                string jsonSnippet = string.Empty;
+                string stringSnippet;
+                // Create a regex to find unescaped double quotes in the string snippet
+                System.Text.RegularExpressions.Regex regexUnescaped = new(@"(?<!\\)""", System.Text.RegularExpressions.RegexOptions.Singleline);
                 // iterate over all matches
                 foreach (System.Text.RegularExpressions.Match match in matches)
                 {
-                    jsonSnippet = match.Groups[1].Value;
-                    // Try to parse the JSON to see if it's valid
-                    try
-                    {
-                        _ = JsonDocument.Parse(jsonSnippet); // success = unescaped
-                    }
-                    catch
-                    {
-                        // Already escaped or malformed – don't re-escape
-                        continue;
-                    }
+                    stringSnippet = match.Groups[1].Value;
 
-                    // replace all double quotes with escaped double quotes
-                    var escapedSnipped = jsonSnippet.Replace("\"", "\\\"");
-                    // replace the original match with the escaped match
-                    decodedWebPart = decodedWebPart.Replace(jsonSnippet, escapedSnipped);
+                    // Check for at least one unescaped double quote
+                    if (regexUnescaped.IsMatch(stringSnippet))
+                    {
+                        // replace all double quotes with escaped double quotes
+                        var escapedSnipped = regexUnescaped.Replace(stringSnippet, "\\\"");
+
+                        // replace the original match with the escaped match
+                        decodedWebPart = decodedWebPart.Replace(stringSnippet, escapedSnipped);
+                    }
                 }
             }
 

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -688,7 +688,7 @@ namespace PnP.Core.Model.SharePoint
                     // Check for at least one unescaped double quote
                     if (regexUnescaped.IsMatch(stringSnippet))
                     {
-                        // replace all double quotes with escaped double quotes
+                        // replace all unescaped double quotes with escaped double quotes
                         var escapedSnipped = regexUnescaped.Replace(stringSnippet, "\\\"");
 
                         // replace the original match with the escaped match


### PR DESCRIPTION
After further tests, I improved the validation, not only for a JSON value but, to escape any unescaped double quote in a string that should be escaped ( related to https://github.com/pnp/pnpcore/pull/1674 )

Examples:
`"TemplateHtml": ".... class=\"portal-search-page\" data-config-json=\"{ "k1":"v1", "k2":"{v2}", "k3": ["k4":"v4","k5":"v5"] }\" ) ...`

OR

`"Content":"<span style=\"font-family: "Segoe Sans", "Segoe UI", "Segoe UI Web (West European)", -apple-system, BlinkMacSystemFont, Roboto, "Helvetica Neue", sans-serif; font-size: 16px; background-color: rgb(76, 125, 191);\"`
