### PR TITLE
support modern header footer

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
@@ -813,7 +813,126 @@ namespace PnP.Core.Model.SharePoint
                 context.Web.SetSystemProperty(p => p.FooterLayout, chromeOptions.Footer.Layout);
             }
         }
+        #endregion
 
+        #region font
+
+        public async Task<List<IFontPackage>> GetOutOfBoxFontPackagesAsync()
+        {
+            var batch = context.NewBatch();
+            var fontPackages = await GetOutOfBoxFontPackagesBatchAsync(batch).ConfigureAwait(false);
+            await context.ExecuteAsync(batch).ConfigureAwait(false);
+            return fontPackages.Result;
+        }
+
+        public List<IFontPackage> GetOutOfBoxFontPackages()
+        {
+            return GetOutOfBoxFontPackagesAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<IBatchSingleResult<List<IFontPackage>>> GetOutOfBoxFontPackagesBatchAsync(Batch batch)
+        {
+            ApiCall apiCall = BuildGetOutOfBoxFontPackagesApiCall();
+            return await GetFontPackagesBatchAsync(batch, apiCall).ConfigureAwait(false);
+        }
+
+        public IBatchSingleResult<List<IFontPackage>> GetOutOfBoxFontPackagesBatch(Batch batch)
+        {
+            return GetOutOfBoxFontPackagesBatchAsync(batch).GetAwaiter().GetResult();
+        }
+
+        public async Task<List<IFontPackage>> GetFontPackagesAsync()
+        {
+            var batch = context.NewBatch();
+            var fontPackages = await GetFontPackagesBatchAsync(batch).ConfigureAwait(false);
+            await context.ExecuteAsync(batch).ConfigureAwait(false);
+            return fontPackages.Result;
+        }
+
+        public List<IFontPackage> GetFontPackages()
+        {
+            return GetFontPackagesAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<IBatchSingleResult<List<IFontPackage>>> GetFontPackagesBatchAsync(Batch batch)
+        {
+            ApiCall apiCall = BuildGetFontPackagesApiCall();
+            return await GetFontPackagesBatchAsync(batch, apiCall).ConfigureAwait(false);
+        }
+
+        public IBatchSingleResult<List<IFontPackage>> GetFontPackagesBatch(Batch batch)
+        {
+            return GetFontPackagesBatchAsync(batch).GetAwaiter().GetResult();
+        }
+
+        public async Task<List<IFontPackage>> GetSiteFontPackagesAsync()
+        {
+            var batch = context.NewBatch();
+            var fontPackages = await GetSiteFontPackagesBatchAsync(batch).ConfigureAwait(false);
+            await context.ExecuteAsync(batch).ConfigureAwait(false);
+            return fontPackages.Result;
+        }
+
+        public List<IFontPackage> GetSiteFontPackages()
+        {
+            return GetSiteFontPackagesAsync().GetAwaiter().GetResult();
+        }
+
+        public async Task<IBatchSingleResult<List<IFontPackage>>> GetSiteFontPackagesBatchAsync(Batch batch)
+        {
+            ApiCall apiCall = BuildGetSiteFontPackagesApiCall();
+            return await GetFontPackagesBatchAsync(batch, apiCall).ConfigureAwait(false);
+        }
+
+        public IBatchSingleResult<List<IFontPackage>> GetSiteFontPackagesBatch(Batch batch)
+        {
+            return GetSiteFontPackagesBatchAsync(batch).GetAwaiter().GetResult();
+        }
+
+        private static ApiCall BuildGetSiteFontPackagesApiCall()
+        {
+            return new ApiCall("_api/SiteFontPackages", ApiType.SPORest);
+        }
+
+        private static ApiCall BuildGetOutOfBoxFontPackagesApiCall()
+        {
+            return new ApiCall("_api/OutOfBoxFontPackages", ApiType.SPORest);
+        }
+
+        private static ApiCall BuildGetFontPackagesApiCall()
+        {
+            return new ApiCall("_api/FontPackages", ApiType.SPORest);
+        }
+
+        internal async Task<IBatchSingleResult<List<IFontPackage>>> GetFontPackagesBatchAsync(Batch batch, ApiCall apiCall)
+        {
+            // Since we're doing a raw batch request the processing of the batch response needs be implemented
+            apiCall.RawSingleResult = new List<IFontPackage>();
+            apiCall.RawResultsHandler = (json, apiCall) =>
+            {
+                ProcessGetFontPackagesResponse(json, (List<IFontPackage>)apiCall.RawSingleResult);
+            };
+
+            // Add the request to the batch
+            var batchRequest = await (context.Web as Web).RawRequestBatchAsync(batch, apiCall, HttpMethod.Get).ConfigureAwait(false);
+
+            // Return the batch result as Enumerable
+            return new BatchSingleResult<List<IFontPackage>>(batch, batchRequest.Id, (List<IFontPackage>)apiCall.RawSingleResult);
+        }
+
+
+        internal static void ProcessGetFontPackagesResponse(string jsonString, List<IFontPackage> fontPackageList)
+        {
+            var jDoc = JsonSerializer.Deserialize<JsonElement>(jsonString);
+            var results = jDoc.GetProperty("value").ValueKind == JsonValueKind.Null ? "[]" : jDoc.GetProperty("value").GetRawText();
+
+            var jsonFontPackageList = JsonSerializer.Deserialize<List<FontPackage>>(results);
+
+            foreach (var fontPackage in jsonFontPackageList)
+            {
+                fontPackageList.Add(fontPackage);
+            }
+        }
         #endregion
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
@@ -534,14 +534,13 @@ namespace PnP.Core.Model.SharePoint
                 }
             }
 
-
+            chromeOptions.Font = new FontOptions();
             //Font Options
-            if(web.AllProperties.Values.TryGetValue("FontOptionForSiteTitle", out var FontOptionForSiteTitle) 
+            if (web.AllProperties.Values.TryGetValue("FontOptionForSiteTitle", out var FontOptionForSiteTitle) 
                 | web.AllProperties.Values.TryGetValue("FontOptionForSiteNav", out var FontOptionForSiteNav)
                 | web.AllProperties.Values.TryGetValue("FontOptionForSiteFooterTitle", out var FontOptionForSiteFooterTitle)
                 | web.AllProperties.Values.TryGetValue("FontOptionForSiteFooterNav", out var FontOptionForSiteFooterNav))
             {
-                chromeOptions.Font = new FontOptions();
                 if(!string.IsNullOrWhiteSpace(FontOptionForSiteTitle?.ToString()))
                 {
                     chromeOptions.Font.SiteTitle = JsonSerializer.Deserialize<FontOption>(FontOptionForSiteTitle.ToString());

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
@@ -425,7 +425,8 @@ namespace PnP.Core.Model.SharePoint
                                         p => p.HorizontalQuickLaunch,
                                         // Load these properties now as they're needed in the HasCommunicationSiteFeaturesAsync method
                                         p => p.WebTemplate,
-                                        p => p.Features).ConfigureAwait(false);
+                                        p => p.Features,
+                                        p => p.AllProperties).ConfigureAwait(false);
 
             var menuState = await GetMenuStateBatchAsync(batch).ConfigureAwait(false);
 
@@ -451,6 +452,28 @@ namespace PnP.Core.Model.SharePoint
                 Emphasis = web.HeaderEmphasis
             };
 
+            // Modern Header Feature MC1098935
+            if (web.AllProperties.Values.TryGetValue("HeaderOverlayColor", out var HeaderOverlayColor) && int.TryParse(HeaderOverlayColor.ToString(), out var headerOverlayColor) && Enum.IsDefined(typeof(OverlayColorType), headerOverlayColor))
+            {
+                chromeOptions.Header.OverlayColor = (OverlayColorType)headerOverlayColor;
+            }
+            if (web.AllProperties.Values.TryGetValue("HeaderOverlayOpacity", out var HeaderOverlayOpacity) && int.TryParse(HeaderOverlayOpacity.ToString(), out var headerOverlayOpacity))
+            {
+                chromeOptions.Header.OverlayOpacity = headerOverlayOpacity;
+            }
+            if (web.AllProperties.Values.TryGetValue("HeaderOverlayGradientDirection", out var HeaderOverlayGradientDirection) && int.TryParse(HeaderOverlayGradientDirection.ToString(), out var headerOverlayGradientDirection) && Enum.IsDefined(typeof(OverlayGradientDirectionType), headerOverlayGradientDirection))
+            {
+                chromeOptions.Header.OverlayGradientDirection = (OverlayGradientDirectionType)headerOverlayGradientDirection;
+            }
+            if (web.AllProperties.Values.TryGetValue("HeaderColorIndexInLightMode", out var HeaderColorIndexInLightMode) && int.TryParse(HeaderColorIndexInLightMode.ToString(), out var headerColorIndexInLightMode))
+            {
+                chromeOptions.Header.ColorIndexInLightMode = headerColorIndexInLightMode;
+            }
+            if (web.AllProperties.Values.TryGetValue("HeaderColorIndexInDarkMode", out var HeaderColorIndexInDarkMode) && int.TryParse(HeaderColorIndexInDarkMode.ToString(), out var headerColorIndexInDarkMode))
+            {
+                chromeOptions.Header.ColorIndexInDarkMode = headerColorIndexInDarkMode;
+            }
+
             chromeOptions.Navigation = new NavigationOptions
             {
                 MegaMenuEnabled = web.MegaMenuEnabled,
@@ -467,6 +490,34 @@ namespace PnP.Core.Model.SharePoint
                     Enabled = web.FooterEnabled
                 };
 
+                // Modern Footer Feature MC1098935
+                if (web.AllProperties.Values.TryGetValue("FooterAlignment", out var FooterAlignment) && int.TryParse(FooterAlignment.ToString(), out var footerAlignment) && Enum.IsDefined(typeof(FooterLinkAlignment), footerAlignment))
+                {
+                    chromeOptions.Footer.LinkAlignment = (FooterLinkAlignment)footerAlignment;
+                }
+                if (web.AllProperties.Values.TryGetValue("FooterOverlayColor", out var FooterOverlayColor) && int.TryParse(FooterOverlayColor.ToString(), out var footerOverlayColor) && Enum.IsDefined(typeof(OverlayColorType), footerOverlayColor))
+                {
+                    chromeOptions.Footer.OverlayColor = (OverlayColorType)footerOverlayColor;
+                }
+                if (web.AllProperties.Values.TryGetValue("FooterOverlayOpacity", out var FooterOverlayOpacity) && int.TryParse(FooterOverlayOpacity.ToString(), out var footerOverlayOpacity))
+                {
+                    chromeOptions.Footer.OverlayOpacity = footerOverlayOpacity;
+                }
+                if (web.AllProperties.Values.TryGetValue("FooterOverlayGradientDirection", out var FooterOverlayGradientDirection) && int.TryParse(FooterOverlayGradientDirection.ToString(), out var footerOverlayGradientDirection) && Enum.IsDefined(typeof(OverlayGradientDirectionType), footerOverlayGradientDirection))
+                {
+                    chromeOptions.Footer.OverlayGradientDirection = (OverlayGradientDirectionType)footerOverlayGradientDirection;
+                }
+
+                if (web.AllProperties.Values.TryGetValue("FooterColorIndexInLightMode", out var FooterColorIndexInLightMode) && int.TryParse(FooterColorIndexInLightMode.ToString(), out var footerColorIndexInLightMode))
+                {
+                    chromeOptions.Footer.ColorIndexInLightMode = footerColorIndexInLightMode;
+                }
+                if (web.AllProperties.Values.TryGetValue("FooterColorIndexInDarkMode", out var FooterColorIndexInDarkMode) && int.TryParse(FooterColorIndexInDarkMode.ToString(), out var footerColorIndexInDarkMode))
+                {
+                    chromeOptions.Footer.ColorIndexInDarkMode = footerColorIndexInDarkMode;
+                }
+
+
                 if (menuState != null)
                 {
                     (chromeOptions.Footer as FooterOptions).MenuState = menuState;
@@ -480,6 +531,32 @@ namespace PnP.Core.Model.SharePoint
                             chromeOptions.Footer.DisplayName = displayNameNode.Title;
                         }
                     }
+                }
+            }
+
+
+            //Font Options
+            if(web.AllProperties.Values.TryGetValue("FontOptionForSiteTitle", out var FontOptionForSiteTitle) 
+                | web.AllProperties.Values.TryGetValue("FontOptionForSiteNav", out var FontOptionForSiteNav)
+                | web.AllProperties.Values.TryGetValue("FontOptionForSiteFooterTitle", out var FontOptionForSiteFooterTitle)
+                | web.AllProperties.Values.TryGetValue("FontOptionForSiteFooterNav", out var FontOptionForSiteFooterNav))
+            {
+                chromeOptions.Font = new FontOptions();
+                if(!string.IsNullOrWhiteSpace(FontOptionForSiteTitle?.ToString()))
+                {
+                    chromeOptions.Font.SiteTitle = JsonSerializer.Deserialize<FontOption>(FontOptionForSiteTitle.ToString());
+                }
+                if (!string.IsNullOrWhiteSpace(FontOptionForSiteNav?.ToString()))
+                {
+                    chromeOptions.Font.SiteNav = JsonSerializer.Deserialize<FontOption>(FontOptionForSiteNav.ToString());
+                }
+                if (!string.IsNullOrWhiteSpace(FontOptionForSiteFooterTitle?.ToString()))
+                {
+                    chromeOptions.Font.SiteFooterTitle = JsonSerializer.Deserialize<FontOption>(FontOptionForSiteFooterTitle.ToString());
+                }
+                if (!string.IsNullOrWhiteSpace(FontOptionForSiteFooterNav?.ToString()))
+                {
+                    chromeOptions.Font.SiteFooterNav = JsonSerializer.Deserialize<FontOption>(FontOptionForSiteFooterNav.ToString());
                 }
             }
         }
@@ -504,7 +581,8 @@ namespace PnP.Core.Model.SharePoint
                                                 p => p.HorizontalQuickLaunch,
                                                 // Load these properties now as they're needed in the HasCommunicationSiteFeaturesAsync method
                                                 p => p.WebTemplate,
-                                                p => p.Features).ConfigureAwait(false);
+                                                p => p.Features,
+                                                p => p.AllProperties).ConfigureAwait(false);
             
             var menuState = await GetMenuStateBatchAsync(batch).ConfigureAwait(false);
 
@@ -593,13 +671,28 @@ namespace PnP.Core.Model.SharePoint
             {
                 headerLayout = chromeOptions.Header.Layout,
                 headerEmphasis = chromeOptions.Header.Emphasis,
+                headerOverlayColor = chromeOptions.Header.OverlayColor,
+                headerOverlayOpacity = chromeOptions.Header.OverlayOpacity,
+                headerOverlayGradientDirection = chromeOptions.Header.OverlayGradientDirection,
+                headerColorIndexInLightMode = chromeOptions.Header.ColorIndexInLightMode,
+                headerColorIndexInDarkMode = chromeOptions.Header.ColorIndexInDarkMode,
                 hideTitleInHeader = chromeOptions.Header.HideTitle,
                 logoAlignment = chromeOptions.Header.LogoAlignment,
                 megaMenuEnabled = chromeOptions.Navigation != null ? chromeOptions.Navigation.MegaMenuEnabled : false,
                 horizontalQuickLaunch = chromeOptions.Navigation != null ? chromeOptions.Navigation.HorizontalQuickLaunch : false,
                 footerEnabled = chromeOptions.Footer != null ? chromeOptions.Footer.Enabled : false,
                 footerLayout = chromeOptions.Footer != null ? chromeOptions.Footer.Layout : FooterLayoutType.Simple,
-                footerEmphasis = chromeOptions.Footer != null ? chromeOptions.Footer.Emphasis : FooterVariantThemeType.Strong
+                footerEmphasis = chromeOptions.Footer != null ? chromeOptions.Footer.Emphasis : FooterVariantThemeType.Strong,
+                footerAlignment = chromeOptions.Footer != null ? chromeOptions.Footer.LinkAlignment: FooterLinkAlignment.Right,
+                footerOverlayColor = chromeOptions.Footer != null ? chromeOptions.Footer.OverlayColor : OverlayColorType.None,
+                footerOverlayOpacity = chromeOptions.Footer != null ? chromeOptions.Footer.OverlayOpacity : 0,
+                footerOverlayGradientDirection = chromeOptions.Footer != null ? chromeOptions.Footer.OverlayGradientDirection : OverlayGradientDirectionType.TopToBottom,
+                footerColorIndexInLightMode = chromeOptions.Footer != null ? chromeOptions.Footer.ColorIndexInLightMode : -1,
+                footerColorIndexInDarkMode = chromeOptions.Footer != null ? chromeOptions.Footer.ColorIndexInDarkMode : -1,
+                fontOptionForSiteTitle = chromeOptions.Font != null ? chromeOptions.Font.SiteTitle : null,
+                fontOptionForSiteNav = chromeOptions.Font != null ? chromeOptions.Font.SiteNav : null,
+                fontOptionForSiteFooterTitle = chromeOptions.Font != null ? chromeOptions.Font.SiteFooterTitle : null,
+                fontOptionForSiteFooterNav = chromeOptions.Font != null ? chromeOptions.Font.SiteFooterNav : null,
             };
 
             string jsonBody = JsonSerializer.Serialize(body);

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/BrandingManager.cs
@@ -815,7 +815,7 @@ namespace PnP.Core.Model.SharePoint
         }
         #endregion
 
-        #region font
+        #region OutOfBoxFontPackages
 
         public async Task<List<IFontPackage>> GetOutOfBoxFontPackagesAsync()
         {
@@ -841,6 +841,50 @@ namespace PnP.Core.Model.SharePoint
             return GetOutOfBoxFontPackagesBatchAsync(batch).GetAwaiter().GetResult();
         }
 
+        public void SetOutOfBoxFontPackage(string fontId)
+        {
+            SetOutOfBoxFontPackageAsync(fontId).Wait();
+        }
+
+        public async Task SetOutOfBoxFontPackageAsync(string fontId)
+        {
+            var batch = context.NewBatch();
+            SetOutOfBoxFontPackageBatch(batch, fontId);
+            await context.ExecuteAsync(batch).ConfigureAwait(false);
+        }
+
+        public void SetOutOfBoxFontPackageBatch(Batch batch, string fontId)
+        {
+            SetOutOfBoxFontPackageBatchAsync(batch, fontId).GetAwaiter().GetResult();
+        }
+
+        public Task SetOutOfBoxFontPackageBatchAsync(Batch batch, string fontId)
+        {
+            BuildAndSetOutOfBoxFontPackageApiCall(batch, fontId).Wait();
+            return Task.CompletedTask;
+        }
+
+        private static ApiCall BuildGetOutOfBoxFontPackagesApiCall()
+        {
+            return new ApiCall("_api/OutOfBoxFontPackages", ApiType.SPORest);
+        }
+
+        private async Task BuildAndSetOutOfBoxFontPackageApiCall(Batch batch,string fontId)
+        {
+            var apiCall = new ApiCall($"_api/OutOfBoxFontPackages/GetById('{fontId}')/Apply", ApiType.SPORest)
+            {   // The provided JSON is of the minimal odata type
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json;odata.metadata=nometadata" },
+                }
+            };
+
+            await (context.Web as Web).RawRequestBatchAsync(batch, apiCall, HttpMethod.Post, "SetOutOfBoxFontPackage").ConfigureAwait(false);
+        }
+
+        #endregion OutOfBoxFontPackages
+
+        #region Branding Center FontPackages
         public async Task<List<IFontPackage>> GetFontPackagesAsync()
         {
             var batch = context.NewBatch();
@@ -873,6 +917,50 @@ namespace PnP.Core.Model.SharePoint
             return fontPackages.Result;
         }
 
+        public void SetFontPackage(string fontId)
+        {
+            SetFontPackageAsync(fontId).GetAwaiter().GetResult();
+        }
+
+        public async Task SetFontPackageAsync(string fontId)
+        {
+            var batch = context.NewBatch();
+            SetFontPackageBatch(batch, fontId);
+            await context.ExecuteAsync(batch).ConfigureAwait(false);
+        }
+
+        public void SetFontPackageBatch(Batch batch, string fontId)
+        {
+            SetPackageBatchAsync(batch,fontId).GetAwaiter().GetResult();
+        }
+
+        public Task SetPackageBatchAsync(Batch batch, string fontId)
+        {
+            BuildAndSetFontPackageApiCall(batch, fontId).Wait();
+            return Task.CompletedTask;
+        }
+
+        private static ApiCall BuildGetFontPackagesApiCall()
+        {
+            return new ApiCall("_api/FontPackages", ApiType.SPORest);
+        }
+
+        private async Task BuildAndSetFontPackageApiCall(Batch batch, string fontId)
+        {
+            var apiCall = new ApiCall($"_api/FontPackages/GetById('{fontId}')/Apply", ApiType.SPORest)
+            {   // The provided JSON is of the minimal odata type
+                Headers = new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json;odata.metadata=nometadata" },
+                }
+            };
+
+            await (context.Web as Web).RawRequestBatchAsync(batch, apiCall, HttpMethod.Post, "SetFontPackages").ConfigureAwait(false);
+        }
+
+        #endregion Branding Center FontPackages
+
+        #region SiteFontPackages
         public List<IFontPackage> GetSiteFontPackages()
         {
             return GetSiteFontPackagesAsync().GetAwaiter().GetResult();
@@ -893,16 +981,13 @@ namespace PnP.Core.Model.SharePoint
         {
             return new ApiCall("_api/SiteFontPackages", ApiType.SPORest);
         }
+        #endregion SiteFontPackages
 
-        private static ApiCall BuildGetOutOfBoxFontPackagesApiCall()
+        private async Task SetFontPackageBatchAsync(Batch batch, ApiCall apiCall)
         {
-            return new ApiCall("_api/OutOfBoxFontPackages", ApiType.SPORest);
+            await (context.Web as Web).RawRequestBatchAsync(batch, apiCall, HttpMethod.Post, "SaveMenuState").ConfigureAwait(false);
         }
 
-        private static ApiCall BuildGetFontPackagesApiCall()
-        {
-            return new ApiCall("_api/FontPackages", ApiType.SPORest);
-        }
 
         internal async Task<IBatchSingleResult<List<IFontPackage>>> GetFontPackagesBatchAsync(Batch batch, ApiCall apiCall)
         {
@@ -933,6 +1018,5 @@ namespace PnP.Core.Model.SharePoint
                 fontPackageList.Add(fontPackage);
             }
         }
-        #endregion
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/ChromeOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/ChromeOptions.cs
@@ -17,5 +17,7 @@ namespace PnP.Core.Model.SharePoint
 
         public IFooterOptions Footer { get; internal set; }
 
+        public IFontOptions Font { get; internal set; }
+
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/Enums/SiteLogoType.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/Enums/SiteLogoType.cs
@@ -23,6 +23,11 @@
         /// <summary>
         /// Global navigation logo
         /// </summary>
-        GlobalNavLogo = 3
+        GlobalNavLogo = 3,
+
+        /// <summary>
+        /// Footer background image
+        /// </summary>
+        FooterBackground = 4
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontOption.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontOption.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PnP.Core.Model.SharePoint
+{
+    internal sealed class FontOption : IFontOption
+    {
+        /// <summary>
+        /// fontFamilyKey
+        /// </summary>
+        [JsonPropertyName("fontFamilyKey")]
+        public string FamilyKey { get; set; }
+        /// <summary>
+        /// fontFace
+        /// </summary>
+        [JsonPropertyName("fontFace")]
+        public string Face { get; set; }
+        /// <summary>
+        /// fontVariantWeight
+        /// </summary>
+        [JsonPropertyName("fontVariantWeight")]
+        public string VariantWeight { get; set; }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontOptions.cs
@@ -1,0 +1,10 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    internal sealed class FontOptions : IFontOptions
+    {
+        public IFontOption SiteTitle { get; set; } = null;
+        public IFontOption SiteNav { get; set; } = null;
+        public IFontOption SiteFooterTitle { get; set; } = null;
+        public IFontOption SiteFooterNav { get; set; } = null;
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontPackage.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FontPackage.cs
@@ -1,0 +1,12 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    internal sealed class FontPackage : IFontPackage
+    {
+        public string ID { get; set; }
+        public bool IsHidden { get; set; }
+        public bool IsValid { get; set; }
+        public string PackageJson { get; set; }
+        public int Store { get; set; }
+        public string Title { get; set; }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FooterOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FooterOptions.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace PnP.Core.Model.SharePoint
@@ -106,5 +107,53 @@ namespace PnP.Core.Model.SharePoint
             return menuStateWrapper;
         }
 
+        public async Task SetFooterBackgroundImageAsync(string fileName, Stream content, double focalX = 0, double focalY = 0, bool overwrite = false)
+        {
+            // Upload the image
+            IFile siteLogo = await UploadImageToSiteAssetsAsync(fileName, content, overwrite).ConfigureAwait(false);
+            // Set the uploaded file as header background
+            await (PnPContext.Web as Web).RawRequestAsync(BuildSetSiteLogoApiCall(siteLogo.ServerRelativeUrl, SiteLogoType.FooterBackground, SiteLogoAspect.Square, focalX, focalY), HttpMethod.Post, "SetSiteLogo").ConfigureAwait(false);
+        }
+
+        public void SetFooterBackgroundImage(string fileName, Stream content, double focalX = 0, double focalY = 0, bool overwrite = false)
+        {
+            SetFooterBackgroundImageAsync(fileName, content, focalX, focalY, overwrite).GetAwaiter().GetResult();
+        }
+
+        public async Task ClearFooterBackgroundImageAsync()
+        {
+            await (PnPContext.Web as Web).RawRequestAsync(BuildSetSiteLogoApiCall("", SiteLogoType.FooterBackground, SiteLogoAspect.Square, 0, 0), HttpMethod.Post, "SetSiteLogo").ConfigureAwait(false);
+        }
+
+        public void ClearFooterBackgroundImage()
+        {
+            ClearFooterBackgroundImageAsync().GetAwaiter().GetResult();
+        }
+
+        private static ApiCall BuildSetSiteLogoApiCall(string serverRelativeUrl, SiteLogoType type, SiteLogoAspect aspect, double focalX = 0, double focalY = 0)
+        {
+            string jsonBody;
+            if (type == SiteLogoType.FooterBackground)
+            {
+                jsonBody = JsonSerializer.Serialize(new
+                {
+                    relativeLogoUrl = serverRelativeUrl,
+                    type = (int)type,
+                    aspect = (int)aspect,
+                    focalx = focalX,
+                    focaly = focalY
+                });
+            }
+            else
+            {
+                jsonBody = JsonSerializer.Serialize(new
+                {
+                    relativeLogoUrl = serverRelativeUrl,
+                    type = (int)type,
+                    aspect = (int)aspect
+                });
+            }
+            return new ApiCall("_api/siteiconmanager/setsitelogo", ApiType.SPORest, jsonBody);
+        }
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FooterOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/FooterOptions.cs
@@ -25,6 +25,13 @@ namespace PnP.Core.Model.SharePoint
 
         public string DisplayName { get; set; }
 
+        public FooterLinkAlignment LinkAlignment { get; set; }
+        public OverlayColorType OverlayColor { get; set; }
+        public int OverlayOpacity { get; set; }
+        public OverlayGradientDirectionType OverlayGradientDirection { get; set; }
+        public int ColorIndexInLightMode { get; set; }
+        public int ColorIndexInDarkMode { get; set; }
+
         public async Task SetLogoAsync(string fileName, Stream content, bool overwrite = false)
         {
             // Upload the image

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/HeaderOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/HeaderOptions.cs
@@ -25,6 +25,11 @@ namespace PnP.Core.Model.SharePoint
         public bool HideTitle { get; set; }
 
         public LogoAlignment LogoAlignment { get; set; }
+        public OverlayColorType OverlayColor { get; set; } = OverlayColorType.None;
+        public int OverlayOpacity { get; set; } = 0;
+        public OverlayGradientDirectionType OverlayGradientDirection { get; set; } = OverlayGradientDirectionType.TopToBottom;
+        public int ColorIndexInLightMode { get; set; } = -1;
+        public int ColorIndexInDarkMode { get; set; } = -1;
 
         public async Task SetSiteLogoAsync(string fileName, Stream content, bool overwrite = false)
         {

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/HeaderOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Internal/HeaderOptions.cs
@@ -150,10 +150,11 @@ namespace PnP.Core.Model.SharePoint
 
         public async Task SetHeaderBackgroundImageAsync(string fileName, Stream content, double focalX = 0, double focalY = 0, bool overwrite = false)
         {
-            if (Layout != HeaderLayoutType.Extended)
-            {
-                throw new ClientException(ErrorType.Unsupported, PnPCoreResources.Exception_Unsupported_BackgroundImageHeaderIsNotOfTypeExtended);
-            }
+            // => modern Header does allow background images for all layouts
+            //if (Layout != HeaderLayoutType.Extended)
+            //{
+            //    throw new ClientException(ErrorType.Unsupported, PnPCoreResources.Exception_Unsupported_BackgroundImageHeaderIsNotOfTypeExtended);
+            //}
 
             // Upload the image
             IFile siteLogo = await UploadImageToSiteAssetsAsync(fileName, content, overwrite).ConfigureAwait(false);

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IBrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IBrandingManager.cs
@@ -224,7 +224,7 @@ namespace PnP.Core.Model.SharePoint
         void SetChromeOptionsBatch(IChromeOptions chromeOptions);
         #endregion
 
-        #region Fonts
+        #region OutOfBoxFontPackages
 
         /// <summary>
         /// Gets the out of the box fonts available
@@ -241,6 +241,7 @@ namespace PnP.Core.Model.SharePoint
         /// <summary>
         /// Gets the out of the box fonts available
         /// </summary>
+        /// <param name="batch"></param>
         /// <returns>Site's <see cref="IFontPackage"/></returns>
         Task<IBatchSingleResult<List<IFontPackage>>> GetOutOfBoxFontPackagesBatchAsync(Batch batch);
 
@@ -249,6 +250,36 @@ namespace PnP.Core.Model.SharePoint
         /// </summary>
         /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
         IBatchSingleResult<List<IFontPackage>> GetOutOfBoxFontPackagesBatch(Batch batch);
+
+        /// <summary>
+        /// Sets the out of the box font with the given id on the Site
+        /// </summary>
+        /// <param name="fontId"></param>
+        void SetOutOfBoxFontPackage(string fontId);
+
+        /// <summary>
+        /// Sets the out of the box font with the given id on the Site
+        /// </summary>
+        /// <param name="fontId"></param>
+        Task SetOutOfBoxFontPackageAsync(string fontId);
+
+        /// <summary>
+        /// Sets the out of the box font with the given id on the Site
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <param name="fontId"></param>
+        void SetOutOfBoxFontPackageBatch(Batch batch, string fontId);
+
+        /// <summary>
+        /// Sets the out of the box font with the given id on the Site
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <param name="fontId"></param>
+        Task SetOutOfBoxFontPackageBatchAsync(Batch batch, string fontId);
+
+        #endregion OutOfBoxFontPackages
+
+        #region Branding Center FontPackages
 
         /// <summary>
         /// Gets the fonts available in branding center
@@ -275,6 +306,36 @@ namespace PnP.Core.Model.SharePoint
         IBatchSingleResult<List<IFontPackage>> GetFontPackagesBatch(Batch batch);
 
         /// <summary>
+        /// Sets the branding center font with the given id on the Site
+        /// </summary>
+        /// <param name="fontId"></param>
+        void SetFontPackage(string fontId);
+
+        /// <summary>
+        /// Sets the branding center font with the given id on the Site
+        /// </summary>
+        /// <param name="fontId"></param>
+        Task SetFontPackageAsync(string fontId);
+
+        /// <summary>
+        /// Sets the branding center font with the given id on the Site
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <param name="fontId"></param>
+        void SetFontPackageBatch(Batch batch, string fontId);
+
+        /// <summary>
+        /// Sets the branding center font with the given id on the Site
+        /// </summary>
+        /// <param name="batch"></param>
+        /// <param name="fontId"></param>
+        Task SetPackageBatchAsync(Batch batch, string fontId);
+
+        #endregion Branding Center FontPackages
+
+        #region SiteFontPackages
+
+        /// <summary>
         /// Gets the fonts installed on the site
         /// </summary>
         /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
@@ -298,6 +359,6 @@ namespace PnP.Core.Model.SharePoint
         /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
         IBatchSingleResult<List<IFontPackage>> GetSiteFontPackagesBatch(Batch batch);
 
-        #endregion
+        #endregion SiteFontPackages
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IBrandingManager.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IBrandingManager.cs
@@ -223,5 +223,81 @@ namespace PnP.Core.Model.SharePoint
         /// <returns></returns>
         void SetChromeOptionsBatch(IChromeOptions chromeOptions);
         #endregion
+
+        #region Fonts
+
+        /// <summary>
+        /// Gets the out of the box fonts available
+        /// </summary>
+        /// <returns>Site's <see cref="IFontPackage"/></returns>
+        Task<List<IFontPackage>> GetOutOfBoxFontPackagesAsync();
+
+        /// <summary>
+        /// Gets the out of the box fonts available
+        /// </summary>
+        /// <returns>Site's <see cref="IFontPackage"/></returns>
+        List<IFontPackage> GetOutOfBoxFontPackages();
+
+        /// <summary>
+        /// Gets the out of the box fonts available
+        /// </summary>
+        /// <returns>Site's <see cref="IFontPackage"/></returns>
+        Task<IBatchSingleResult<List<IFontPackage>>> GetOutOfBoxFontPackagesBatchAsync(Batch batch);
+
+        /// <summary>
+        /// Gets the out of the box fonts available
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        IBatchSingleResult<List<IFontPackage>> GetOutOfBoxFontPackagesBatch(Batch batch);
+
+        /// <summary>
+        /// Gets the fonts available in branding center
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        Task<List<IFontPackage>> GetFontPackagesAsync();
+
+        /// <summary>
+        /// Gets the fonts available in branding center
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        List<IFontPackage> GetFontPackages();
+
+        /// <summary>
+        /// Gets the fonts available in branding center
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        Task<IBatchSingleResult<List<IFontPackage>>> GetFontPackagesBatchAsync(Batch batch);
+
+        /// <summary>
+        /// Gets the fonts available in branding center
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        IBatchSingleResult<List<IFontPackage>> GetFontPackagesBatch(Batch batch);
+
+        /// <summary>
+        /// Gets the fonts installed on the site
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        Task<List<IFontPackage>> GetSiteFontPackagesAsync();
+
+        /// <summary>
+        /// Gets the fonts installed on the site
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        List<IFontPackage> GetSiteFontPackages();
+
+        /// <summary>
+        /// Gets the fonts installed on the site
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        Task<IBatchSingleResult<List<IFontPackage>>> GetSiteFontPackagesBatchAsync(Batch batch);
+
+        /// <summary>
+        /// Gets the fonts installed on the site
+        /// </summary>
+        /// <returns>Site's <see cref="System.Collections.Generic.List{IFontPackage}"/></returns>
+        IBatchSingleResult<List<IFontPackage>> GetSiteFontPackagesBatch(Batch batch);
+
+        #endregion
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IChromeOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IChromeOptions.cs
@@ -20,5 +20,9 @@
         /// </summary>
         IFooterOptions Footer { get; }
 
+        /// <summary>
+        /// Site font chrome configuration
+        /// </summary>
+        IFontOptions Font { get; }
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontOption.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontOption.cs
@@ -1,0 +1,28 @@
+﻿using System.Text.Json.Serialization;
+
+namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// specify font to use for header / footer
+    /// </summary>
+    public interface IFontOption
+    {
+        /// <summary>
+        /// fontFamilyKey
+        /// </summary>
+        [JsonPropertyName("fontFamilyKey")]
+        string FamilyKey { get; set; }
+
+        /// <summary>
+        /// fontFace
+        /// </summary>
+        [JsonPropertyName("fontFace")] 
+        string Face { get; set; }
+
+        /// <summary>
+        /// fontVariantWeight
+        /// </summary>
+        [JsonPropertyName("fontVariantWeight")]
+        string VariantWeight { get; set; }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontOptions.cs
@@ -1,0 +1,28 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// Options to configure a the site font chrome.
+    /// </summary>
+    public interface IFontOptions
+    {
+        /// <summary>
+        /// fontOptionForSiteTitle
+        /// </summary>
+        IFontOption SiteTitle { get; set; }
+
+        /// <summary>
+        /// fontOptionForSiteNav
+        /// </summary>
+        IFontOption SiteNav { get; set; }
+
+        /// <summary>
+        /// fontOptionForSiteFooterTitle
+        /// </summary>
+        IFontOption SiteFooterTitle { get; set; }
+
+        /// <summary>
+        /// fontOptionForSiteFooterNav
+        /// </summary>
+        IFontOption SiteFooterNav { get; set; }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontPackage.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFontPackage.cs
@@ -1,0 +1,41 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// Returned by
+    /// /_api/OutOfBoxFontPackages
+    /// /_api/SiteFontPackages
+    /// /_api/FontPackages
+    /// </summary>
+    public interface IFontPackage
+    {
+        /// <summary>
+        /// Font Package ID example /_api/OutOfBoxFontPackages/GetById('5f955493-db94-446f-93bf-2c7567861329')
+        /// </summary>
+        string ID { get; set; }
+
+        /// <summary>
+        /// dont show this font in the font picker
+        /// </summary>
+        bool IsHidden { get; set; }
+        
+        /// <summary>
+        /// IsValid
+        /// </summary>
+        bool IsValid { get; set; }
+
+        /// <summary>
+        /// json-string containg settings for the font package
+        /// </summary>
+        string PackageJson { get; set; }
+
+        /// <summary>
+        /// 0 = Branding Center, 1 = out of the box font
+        /// </summary>
+        int Store { get; set; }
+
+        /// <summary>
+        /// display name of the font package
+        /// </summary>
+        string Title { get; set; }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFooterOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFooterOptions.cs
@@ -86,5 +86,40 @@ namespace PnP.Core.Model.SharePoint
         /// </summary>
         /// <returns></returns>
         void ClearLogo();
+
+
+        /// <summary>
+        /// Sets the site's footer background image.
+        /// </summary>
+        /// <param name="fileName">Name of your image file</param>
+        /// <param name="content">The contents of the file</param>
+        /// <param name="focalX">X axis focal point for the footer image</param>
+        /// <param name="focalY">Y axis focal point for the footer image</param>
+        /// <param name="overwrite">Indicates whether the file should be overwritten if already existing.</param>
+        /// <returns></returns>
+        Task SetFooterBackgroundImageAsync(string fileName, Stream content, double focalX = 0, double focalY = 0, bool overwrite = false);
+
+        /// <summary>
+        /// Sets the site's footer background image. 
+        /// </summary>
+        /// <param name="fileName">Name of your image file</param>
+        /// <param name="content">The contents of the file</param>
+        /// <param name="focalX">X axis focal point for the footer image</param>
+        /// <param name="focalY">Y axis focal point for the footer image</param>
+        /// <param name="overwrite">Indicates whether the file should be overwritten if already existing.</param>
+        /// <returns></returns>
+        void SetFooterBackgroundImage(string fileName, Stream content, double focalX = 0, double focalY = 0, bool overwrite = false);
+
+        /// <summary>
+        /// Clears the footer background image
+        /// </summary>
+        /// <returns></returns>
+        Task ClearFooterBackgroundImageAsync();
+
+        /// <summary>
+        /// Clears the footer background image
+        /// </summary>
+        /// <returns></returns>
+        void ClearFooterBackgroundImage();
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFooterOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IFooterOptions.cs
@@ -24,6 +24,35 @@ namespace PnP.Core.Model.SharePoint
         FooterVariantThemeType Emphasis { get; set; }
 
         /// <summary>
+        /// specifies the alignment of links in the footer
+        /// </summary>
+        FooterLinkAlignment LinkAlignment { get; set; }
+        
+        /// <summary>
+        /// Specifies the available overlay color types that can be applied to header or footer.
+        /// </summary>
+        OverlayColorType OverlayColor { get; set; }
+        /// <summary>
+        /// Gets or sets the opacity level of the overlay [0-100].
+        /// </summary>
+        int OverlayOpacity { get; set; }
+
+        /// <summary>
+        /// Defines the possible directions for an overlay gradient layout.
+        /// </summary>
+        OverlayGradientDirectionType OverlayGradientDirection { get; set; }
+
+        /// <summary>
+        /// seesm to be alays -1
+        /// </summary>
+        int ColorIndexInLightMode { get; set; }
+
+        /// <summary>
+        /// seesm to be alays -1
+        /// </summary>
+        int ColorIndexInDarkMode { get; set; }
+
+        /// <summary>
         /// The footer display name
         /// </summary>
         string DisplayName { get; set; }

--- a/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IHeaderOptions.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Branding/Public/IHeaderOptions.cs
@@ -29,6 +29,31 @@ namespace PnP.Core.Model.SharePoint
         public LogoAlignment LogoAlignment { get; set; }
 
         /// <summary>
+        /// Specifies the available overlay color types that can be applied to header or footer.
+        /// </summary>
+        public OverlayColorType OverlayColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the opacity level of the overlay [0-100].
+        /// </summary>
+        public int OverlayOpacity { get; set; }
+
+        /// <summary>
+        /// Defines the possible directions for an overlay gradient layout.
+        /// </summary>
+        public OverlayGradientDirectionType OverlayGradientDirection { get; set; }
+
+        /// <summary>
+        /// seesm to be alays -1
+        /// </summary>
+        public int ColorIndexInLightMode { get; set; }
+
+        /// <summary>
+        /// seesm to be alays -1
+        /// </summary>
+        public int ColorIndexInDarkMode { get; set; }
+
+        /// <summary>
         /// Sets the site's logo to the provided image.  For group connected sites calling this method is 
         /// equal to calling SetSiteLogoThumbnail as logo and logo thumbnail are both set the same.
         /// </summary>

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/FooterLinkAlignment.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/FooterLinkAlignment.cs
@@ -1,0 +1,17 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// specifies the alignment of links in the footer
+    /// </summary>
+    public enum FooterLinkAlignment
+    {
+        /// <summary>
+        /// Right alignment ( Value = 0 )
+        /// </summary>
+        Right = 0,
+        /// <summary>
+        /// Left alignment ( Value = 2 )
+        /// </summary>
+        Left = 2,
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/OverlayColorType.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/OverlayColorType.cs
@@ -1,0 +1,32 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// Specifies the available overlay color types that can be applied to header or footer.
+    /// </summary>
+    /// <remarks>This enumeration provides options for selecting predefined overlay colors, including solid
+    /// colors and gradient styles. The values can be used to customize the appearance of UI elements or graphical
+    /// overlays.</remarks>
+    public enum OverlayColorType
+    {
+        /// <summary>
+        /// -1 = not set
+        /// </summary>
+        None = -1,
+        /// <summary>
+        /// 0 = white
+        /// </summary>
+        White = 0,
+        /// <summary>
+        /// 1 = black
+        /// </summary>
+        Black = 1,
+        /// <summary>
+        /// 2 = light gradient
+        /// </summary>
+        LightGradient = 2,
+        /// <summary>
+        /// 3 = dark gradient
+        /// </summary>
+        DarkGradient = 3
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/OverlayGradientDirectionType.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/OverlayGradientDirectionType.cs
@@ -1,0 +1,19 @@
+﻿namespace PnP.Core.Model.SharePoint
+{
+    /// <summary>
+    /// Defines the possible directions for an overlay gradient layout.
+    /// </summary>
+    /// <remarks>This enumeration specifies the orientation of the gradient, determining the direction in
+    /// which the gradient colors are applied.</remarks>
+    public enum OverlayGradientDirectionType
+    {
+        /// <summary>
+        /// Specifies that the layout order proceeds from top to bottom.
+        /// </summary>
+        TopToBottom = 0,
+        /// <summary>
+        /// Specifies that the layout order proceeds from bottom to top.
+        /// </summary>
+        BottomToTop = 1
+    }
+}


### PR DESCRIPTION
@jansenbe implementation of #1690  
Support for new Header and Footer settings
Support to Get available fonts in Branding Manager from Site, OutOfBox, Branding Center (Organization)
Support to Set Font to Site in Branding Manager for OutOfBox and Branding Center Fonts (Organization)

The Chrome properties are reflected as WebProperties:
"HeaderOverlayColor",
"HeaderOverlayOpacity",
"HeaderOverlayGradientDirection",
"HeaderColorIndexInLightMode",
"HeaderColorIndexInDarkMode",
"FooterAlignment",
"FooterOverlayColor",
"FooterOverlayOpacity",
"FooterOverlayGradientDirection",
"FooterColorIndexInLightMode",
"FooterColorIndexInDarkMode",
"FontOptionForSiteTitle",
"FontOptionForSiteNav",
"FontOptionForSiteFooterTitle",
"FontOptionForSiteFooterNav",
"FooterBackgroundImageUrl",
"FooterBackgroundImageFocalPoint",
"BackgroundImageUrl"

But have to be set as /_api/web/SetChromeOptions
{
"headerLayout": 4,
"headerEmphasis": 2,
"megaMenuEnabled": true,
"footerEnabled": true,
"footerLayout": 0,
"footerEmphasis": 0,
"hideTitleInHeader": false,
"logoAlignment": 1,
"footerAlignment": 0,
"footerOverlayColor": -1,
"footerOverlayOpacity": 0,
"footerOverlayGradientDirection": 0,
"headerOverlayColor": 1,
"headerOverlayOpacity": 54,
"headerOverlayGradientDirection": 0,
"fontOptionForSiteTitle": null,
"fontOptionForSiteNav": null,
"fontOptionForSiteFooterTitle": null,
"fontOptionForSiteFooterNav": null,
"horizontalQuickLaunch": true,
"headerColorIndexInLightMode": -1,
"headerColorIndexInDarkMode": -1,
"footerColorIndexInLightMode": -1,
"footerColorIndexInDarkMode": -1
}