### PR TITLE
fix: Load Page Type correctly to fix page header removal

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
@@ -1748,6 +1748,7 @@ namespace PnP.Core.Test.SharePoint
                 // Configure the page header
                 page.RemovePageHeader();
 
+                Assert.IsTrue(page.PageHeader.Type == PageHeaderType.None);
                 Assert.IsTrue(page.PageHeader.LayoutType == PageHeaderLayoutType.NoImage);
                 Assert.IsTrue(page.PageHeader.TextAlignment == PageHeaderTitleAlignment.Left);
                 Assert.IsTrue(page.PageHeader.ShowTopicHeader == false);
@@ -1763,6 +1764,9 @@ namespace PnP.Core.Test.SharePoint
 
                 page = pages.AsEnumerable().First();
 
+                //TODO: Check the page.PageHeader.Type
+
+                Assert.IsTrue(page.PageHeader.Type == PageHeaderType.None);
                 Assert.IsTrue(page.PageHeader.LayoutType == PageHeaderLayoutType.NoImage);
                 Assert.IsTrue(page.PageHeader.TextAlignment == PageHeaderTitleAlignment.Left);
                 Assert.IsTrue(page.PageHeader.ShowTopicHeader == false);

--- a/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
@@ -1764,8 +1764,6 @@ namespace PnP.Core.Test.SharePoint
 
                 page = pages.AsEnumerable().First();
 
-                //TODO: Check the page.PageHeader.Type
-
                 Assert.IsTrue(page.PageHeader.Type == PageHeaderType.None);
                 Assert.IsTrue(page.PageHeader.LayoutType == PageHeaderLayoutType.NoImage);
                 Assert.IsTrue(page.PageHeader.TextAlignment == PageHeaderTitleAlignment.Left);

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageHeader.cs
@@ -346,7 +346,14 @@ namespace PnP.Core.Model.SharePoint
                             {
                                 if (LayoutType == PageHeaderLayoutType.NoImage)
                                 {
-                                    Type = PageHeaderType.Custom;
+                                    if (string.IsNullOrEmpty(pageHeaderControl.InnerHtml))
+                                    {
+                                        Type = PageHeaderType.None;
+                                    }
+                                    else
+                                    {
+                                        Type = PageHeaderType.Custom;
+                                    }
                                 }
                                 else
                                 {


### PR DESCRIPTION
as described in the issue: https://github.com/pnp/pnpcore/issues/1684

Correctly load the page type for a SharePoint page.

The underlying issue is that the Page Type wasn't being loaded correctly even though the RemovePageHeader was correctly removing it.