### PR TITLE
fixes #1698 - Update PropertyValues Id type to string

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/PropertyValues.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/PropertyValues.cs
@@ -25,10 +25,10 @@ namespace PnP.Core.Model.SharePoint
         #endregion
 
         #region Properties
-        public Guid Id { get => GetValue<Guid>(); set => SetValue(value); }
+        public string Id { get => GetValue<string>(); set => SetValue(value); }
 
         [KeyProperty(nameof(Id))]
-        public override object Key { get => Id; set => Id = Guid.Parse(value.ToString()); }
+        public override object Key { get => Id; set => Id = value.ToString(); }
         #endregion
 
         #region Extension methods


### PR DESCRIPTION
fixes 1698 - Update PropertyValues Id type to string to avoid GUID parse exception when getting property bags containing ID field.