### PR TITLE
Fix Approve method to call ApproveAsync, not CheckinAsync

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/File.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/File.cs
@@ -583,7 +583,7 @@ namespace PnP.Core.Model.SharePoint
 
         public void Approve(string comment = null)
         {
-            CheckinAsync(comment).GetAwaiter().GetResult();
+            ApproveAsync(comment).GetAwaiter().GetResult();
         }
 
         public void ApproveBatch(string comment = null)


### PR DESCRIPTION
The Approve method now correctly invokes ApproveAsync instead of CheckinAsync, ensuring the synchronous and asynchronous methods are properly aligned.