### PR TITLE
Updates dependabot behavior. Closes #1743

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to customize dependabot to check and open PRs for github actions and nuget package ecosystems and avoid checking npm. Currently the npm, so package.json based projects, in this repo are only test assets

## 🔗 Related issue 

Closes #1743