### PR TITLE
Fix: section type detection for vertical sections with non-standard c…

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1486,15 +1486,19 @@ namespace PnP.Core.Model.SharePoint
                     }
                     else if (section.Columns.Count == 3)
                     {
-                        if (section.Columns[0].ColumnFactor == 6)
+                        // Use the first non-vertical-section column for type detection,
+                        // as the vertical column (layoutIndex=2) may appear first in the list
+                        var firstMainColumn = section.Columns.Where(c => c.LayoutIndex != 2).OrderBy(c => c.Order).FirstOrDefault();
+                        var mainColumnFactor = firstMainColumn?.ColumnFactor ?? 0;
+                        if (mainColumnFactor == 6)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnVerticalSection;
                         }
-                        else if (section.Columns[0].ColumnFactor == 4)
+                        else if (mainColumnFactor == 4)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnRightVerticalSection;
                         }
-                        else if (section.Columns[0].ColumnFactor == 8)
+                        else if (mainColumnFactor == 8)
                         {
                             section.Type = CanvasSectionTemplate.TwoColumnLeftVerticalSection;
                         }


### PR DESCRIPTION
# Fix: Pages — Vertical section type detection uses wrong column for ColumnFactor check #1756 

## Summary

Fixes a bug where pages with vertical section layouts (`TwoColumnRightVerticalSection`, `TwoColumnLeftVerticalSection`, `TwoColumnVerticalSection`) are misclassified as `OneColumn` during page loading. This causes `ArgumentOutOfRangeException` during PnP provisioning when controls reference columns that don't exist in the incorrectly-typed section.

## Problem

In `Page.cs`, the section type detection for 3-column sections with a vertical section column uses `section.Columns[0].ColumnFactor` to determine the layout type. However, the `Columns` list order is determined by HTML parsing of the page content, and the vertical section column (layoutIndex=2, columnFactor=12) can appear at index 0 if its controls are rendered first in the HTML.

When `Columns[0]` is the vertical column (columnFactor=12), all the `if`/`else if` checks for factors 6, 4, and 8 fail, leaving the section type at the default `OneColumn`.

## Fix

Changed the detection to filter out the vertical section column (layoutIndex=2) before checking `ColumnFactor`:

```diff
 else if (section.Columns.Count == 3)
 {
-    if (section.Columns[0].ColumnFactor == 6)
+    // Use the first non-vertical-section column for type detection,
+    // as the vertical column (layoutIndex=2) may appear first in the list
+    var firstMainColumn = section.Columns
+        .Where(c => c.LayoutIndex != 2)
+        .OrderBy(c => c.Order)
+        .FirstOrDefault();
+    var mainColumnFactor = firstMainColumn?.ColumnFactor ?? 0;
+
+    if (mainColumnFactor == 6)
     {
         section.Type = CanvasSectionTemplate.TwoColumnVerticalSection;
     }
-    else if (section.Columns[0].ColumnFactor == 4)
+    else if (mainColumnFactor == 4)
     {
         section.Type = CanvasSectionTemplate.TwoColumnRightVerticalSection;
     }
-    else if (section.Columns[0].ColumnFactor == 8)
+    else if (mainColumnFactor == 8)
     {
         section.Type = CanvasSectionTemplate.TwoColumnLeftVerticalSection;
     }
 }
```

## File changed

- `src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs` — Section type detection in the page loading logic (around line 1488)

## Testing

- Verified with the `Employee-onboarding-team-home.aspx` page from the standard SharePoint **Employee onboarding** team site template, which uses a `TwoColumnRightVerticalSection` layout
- Before fix: Section exported as `Type="OneColumn"`, provisioning crashed with `ArgumentOutOfRangeException`
- After fix: Section correctly exported as `Type="TwoColumnRightVerticalSection"`, provisioning succeeds

## Related

- There is a companion fix in pnp/pnpframework for the column index mapping of vertical section controls during template export
