### PR TITLE
Adds a attribute name for the internal ID property. Closes #1698

### DIFF
--- a/src/sdk/CHANGELOG.md
+++ b/src/sdk/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Fixed folder not found errors to DirectoryNotFoundException. #1725 [ejazhussain - Ejaz Hussain]
 - Updated console minimal sample for latest .Net and PnP.Core version. #1713 [adam-it - Adam Wójcik]
 - Improved stability when handling guids in GetValidLegacyServicePrincipalAppIdsAsync [jansenbe - Bert Jansen]
+- Added a attribute name for the internal ID property. #1761 [adam-it - Adam Wójcik]
 
 ## [1.15]
 

--- a/src/sdk/PnP.Core.Test/Base/PropertyValuesMappingTests.cs
+++ b/src/sdk/PnP.Core.Test/Base/PropertyValuesMappingTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PnP.Core.Model;
+using PnP.Core.Model.SharePoint;
+using PnP.Core.Services;
+using PnP.Core.Test.Utilities;
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace PnP.Core.Test.Base
+{
+    [TestClass]
+    public class PropertyValuesMappingTests
+    {
+        [ClassInitialize]
+        public static void TestFixtureSetup(TestContext context)
+        {
+            // All these tests are offline by design - no real SharePoint calls are made.
+        }
+
+        [TestMethod]
+        public async Task PropertyValuesWithCustomIdEntry_DoesNotThrow_Issue1698()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var propertyValues = new PropertyValues();
+                ((IDataModelWithContext)propertyValues).PnPContext = context;
+
+                // Simulated SP REST response shape for a folder/file property bag containing
+                // a custom property literally named "ID" with a non-Guid value.
+                using var jsonDoc = JsonDocument.Parse(
+                    "{\"ID\":\"467327\",\"vti_isbrowsable\":\"true\",\"vti_level\":1}");
+
+                var apiCall = new ApiCall("_api/dummy", ApiType.SPORest);
+                var apiResponse = new ApiResponse(apiCall, jsonDoc.RootElement, Guid.NewGuid());
+
+                // Before the fix this throws FormatException trying to Guid.Parse("467327").
+                await ((IDataModelProcess)propertyValues).ProcessResponseAsync(apiResponse);
+
+                // The custom "ID" property bag entry must end up in the overflow dictionary,
+                // not be coerced into the synthetic Id property.
+                Assert.IsTrue(propertyValues.Values.ContainsKey("ID"));
+                Assert.AreEqual("467327", propertyValues.Values["ID"].ToString());
+
+                // The synthetic Id stays unloaded - it has no real server-side counterpart
+                // for SP.PropertyValues, so it must NOT be populated from the user property bag.
+                Assert.IsFalse(propertyValues.HasValue(nameof(PropertyValues.Id)));
+
+                // Other property bag entries are mapped as before.
+                Assert.IsTrue(propertyValues.Values.ContainsKey("vti_isbrowsable"));
+                Assert.AreEqual("true", propertyValues.Values["vti_isbrowsable"].ToString());
+                Assert.IsTrue(propertyValues.Values.ContainsKey("vti_level"));
+            }
+        }
+
+        [TestMethod]
+        public async Task FieldStringValuesWithCustomIdEntry_DoesNotThrow_Issue1698()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var fieldStringValues = new FieldStringValues();
+                ((IDataModelWithContext)fieldStringValues).PnPContext = context;
+
+                using var jsonDoc = JsonDocument.Parse(
+                    "{\"ID\":\"not-an-int\",\"Title\":\"hello\"}");
+
+                var apiCall = new ApiCall("_api/dummy", ApiType.SPORest);
+                var apiResponse = new ApiResponse(apiCall, jsonDoc.RootElement, Guid.NewGuid());
+
+                // Before the fix this throws FormatException trying to int.Parse("not-an-int").
+                await ((IDataModelProcess)fieldStringValues).ProcessResponseAsync(apiResponse);
+
+                Assert.IsTrue(fieldStringValues.Values.ContainsKey("ID"));
+                Assert.AreEqual("not-an-int", fieldStringValues.Values["ID"].ToString());
+                Assert.IsFalse(fieldStringValues.HasValue(nameof(FieldStringValues.Id)));
+                Assert.IsTrue(fieldStringValues.Values.ContainsKey("Title"));
+                Assert.AreEqual("hello", fieldStringValues.Values["Title"].ToString());
+            }
+        }
+    }
+}

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FieldStringValues.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/FieldStringValues.cs
@@ -13,6 +13,7 @@ namespace PnP.Core.Model.SharePoint
         #endregion
 
         #region Properties
+        [SharePointProperty("__PnPCoreKey")]
         public int Id { get => GetValue<int>(); set => SetValue(value); }
 
         [KeyProperty(nameof(Id))]

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/PropertyValues.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/PropertyValues.cs
@@ -25,6 +25,7 @@ namespace PnP.Core.Model.SharePoint
         #endregion
 
         #region Properties
+        [SharePointProperty("__PnPCoreKey")]
         public Guid Id { get => GetValue<Guid>(); set => SetValue(value); }
 
         [KeyProperty(nameof(Id))]


### PR DESCRIPTION
## 🎯

The aim is to add an internal key for the internal ID property so that it avoids conflicts when a user sets a custom ID property on the field, which BTW is a bit of an edge case.

## 🧪 How to test

You may use the file below

[CustomInvalidIdProperty.docx](https://github.com/user-attachments/files/27457051/CustomInvalidIdProperty.docx)

And a similar script to this one.

```
using (var scope = host.Services.CreateScope())
{
    var pnpContextFactory = scope.ServiceProvider.GetRequiredService<IPnPContextFactory>();

    using (var context = await pnpContextFactory.CreateAsync(new Uri(siteUrl)))
    {
        var list = await context.Web.Lists.GetByTitleAsync("Documents", l => l.RootFolder);
        var folder = list.RootFolder;

        using (var stream = new FileStream("PATH_TO_FILE\CustomInvalidIdProperty.docx", FileMode.Open))
        {
            var file = folder.Files.Add("CustomInvalidIdProperty.docx", stream);

            // exception thrown
            file = file.Get(f => f.Properties);
        }
    }
}
```

 Without the fix it will give an error 

<img width="1411" height="262" alt="{4CB87A3B-E645-4F5A-A25C-928B25D1D303}" src="https://github.com/user-attachments/assets/6062e620-b55b-43ea-a236-eeb8030ebf65" />

With the fix it should just work and will map the custom ID property

<img width="1202" height="769" alt="image" src="https://github.com/user-attachments/assets/ff30e9d3-f2ee-474e-9570-bff09498ef9a" />

## 🔗 Related issue

Closes #1698 