### PR TITLE
Adds npm package ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/src"          # Scan /src but NOT /src/assets subfolders
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*"   # Ignore everything found here if no real projects exist


### PR DESCRIPTION
## 🎯 Aim

The aim is to customize dependabot in a way that it will not scan the package.json files of the scr/assets tests projects