### PR TITLE
Fix news page thumbnail that does not appear in the news web parts

### DIFF
--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -1999,13 +1999,16 @@ namespace PnP.Core.Model.SharePoint
                       bannerImageUrlFieldValue.Url.Contains("/_layouts/15/images/sitepagethumbnail.png", StringComparison.InvariantCultureIgnoreCase)))
                 {
                     string previewImageServerRelativeUrl = "";
+                    bool previewImageFromCustomHeader = false;
+
                     if (pageHeader.Type == PageHeaderType.Custom && !string.IsNullOrEmpty(pageHeader.ImageServerRelativeUrl))
                     {
                         previewImageServerRelativeUrl = pageHeader.ImageServerRelativeUrl;
+                        previewImageFromCustomHeader = true;
                     }
                     else
                     {
-                        // iterate the web parts...if we find an unique id then let's grab that information
+                        // iterate the web parts...if we find one with preview image then let's use that information
                         foreach (var control in Controls)
                         {
                             if (control is PageWebPart webPart)
@@ -2020,13 +2023,19 @@ namespace PnP.Core.Model.SharePoint
                     }
 
                     // Validate the found preview image url
-                    if (!string.IsNullOrEmpty(previewImageServerRelativeUrl) &&
-                        !previewImageServerRelativeUrl.StartsWith("/_LAYOUTS", StringComparison.OrdinalIgnoreCase))
+                    if (!string.IsNullOrEmpty(previewImageServerRelativeUrl) && !previewImageServerRelativeUrl.StartsWith("/_LAYOUTS", StringComparison.OrdinalIgnoreCase))
+                    {
+                        if (previewImageFromCustomHeader && pageHeader.HeaderImageId != Guid.Empty)
                     {
                         await PnPContext.Site.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
                         await PnPContext.Web.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
 
                         SetBannerImageUrlField($"{PnPContext.Uri.Scheme}://{PnPContext.Uri.DnsSafeHost}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}");
+                        }
+                        else
+                        {
+                            SetBannerImageUrlField(previewImageServerRelativeUrl);
+                        }
                     }
                 }
             }

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/Page.cs
@@ -2026,11 +2026,11 @@ namespace PnP.Core.Model.SharePoint
                     if (!string.IsNullOrEmpty(previewImageServerRelativeUrl) && !previewImageServerRelativeUrl.StartsWith("/_LAYOUTS", StringComparison.OrdinalIgnoreCase))
                     {
                         if (previewImageFromCustomHeader && pageHeader.HeaderImageId != Guid.Empty)
-                    {
-                        await PnPContext.Site.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
-                        await PnPContext.Web.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
+                        {
+                            await PnPContext.Site.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
+                            await PnPContext.Web.EnsurePropertiesAsync(p => p.Id).ConfigureAwait(false);
 
-                        SetBannerImageUrlField($"{PnPContext.Uri.Scheme}://{PnPContext.Uri.DnsSafeHost}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}");
+                            SetBannerImageUrlField($"{PnPContext.Uri.Scheme}://{PnPContext.Uri.DnsSafeHost}/_layouts/15/getpreview.ashx?guidSite={PnPContext.Site.Id}&guidWeb={PnPContext.Web.Id}&guidFile={pageHeader.HeaderImageId}");
                         }
                         else
                         {


### PR DESCRIPTION
When deploying a News page, the page image does not appear in the News web part.
If editing and publishing the page, the image appears again, so setting the page "BannerImageUrl" makes the image appear in the web part.

<img width="1888" height="372" alt="image" src="https://github.com/user-attachments/assets/e1a3ca4d-4b16-4b7b-9cc9-2fe6ef089a5a" />

This will fix the issue #1783 and may be related to this discussion https://github.com/pnp/pnpframework/discussions/1203

