### PR TITLE
Improves repo security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,21 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/src"          # Scan /src but NOT /src/assets subfolders
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"   # Ignore everything found here if no real projects exist

--- a/.github/workflows/buildandtest.yml
+++ b/.github/workflows/buildandtest.yml
@@ -25,18 +25,20 @@ jobs:
   build:
     if: github.repository_owner == 'pnp'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      actions: read
 
     steps:
     - name: Wait for actions to finish
-      uses: softprops/turnstyle@v3
+      uses: softprops/turnstyle@fa86562458e34a9067f0dc1316a76b3975b1c413 # v3.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}              
-    - name: Checkout dev branch
-      uses: actions/checkout@v7
-      with: 
-        ref: dev
+    - name: Checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '10.0.x'
     - name: Install dependencies
@@ -57,7 +59,7 @@ jobs:
         dotnet test ./PnP.Core.Admin.Test/PnP.Core.Admin.Test.csproj --no-restore --verbosity normal --collect:"XPlat Code Coverage"
       working-directory: src/sdk    
     - name: Upload coverage to Codecov 📝
-      uses: codecov/codecov-action@v7
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: src/sdk/**/coverage.cobertura.xml        

--- a/.github/workflows/cleannightlynuget.yml
+++ b/.github/workflows/cleannightlynuget.yml
@@ -11,15 +11,18 @@ jobs:
     if: github.repository_owner == 'pnp'
     # The type of runner that the job will run on
     runs-on: ubuntu-22.04
+    timeout-minutes: 40
+    permissions:
+      contents: read
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with: 
         ref: dev
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '10.0.x'
     - name: Unlist nightly nuget packages

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      security-events: write
 
     strategy:
       fail-fast: false
@@ -35,11 +39,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -64,7 +68,7 @@ jobs:
     #   make release
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '10.0.x'
         include-prerelease: false
@@ -75,4 +79,4 @@ jobs:
       run:  dotnet build --configuration debug --no-restore --verbosity normal 
       working-directory: src/sdk   
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -11,30 +11,32 @@ jobs:
     if: github.repository_owner == 'pnp'
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     permissions:
       contents: write
+      actions: read
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # prevent parallel executions
     - name: Wait for actions to finish
-      uses: softprops/turnstyle@v3
+      uses: softprops/turnstyle@fa86562458e34a9067f0dc1316a76b3975b1c413 # v3.3.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}    
     # Checks-out dev branch
     - name: Checkout dev branch
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with: 
         ref: dev
         path: dev
     # Checks-out gh-pages branch
     - name: Checkout gh-pages branch
-      uses: actions/checkout@v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with: 
         ref: gh-pages
         path: gh-pages
     # Setup .NET (required for DocFx)
     - name: Setup .NET
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: 8.x
     # Install docfx as a .NET global tool

--- a/.github/workflows/nightlynuget_dev.yml
+++ b/.github/workflows/nightlynuget_dev.yml
@@ -9,13 +9,16 @@ jobs:
   build:
     if: github.repository_owner == 'pnp'
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
 
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with: 
         ref: dev
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@9a946fdbd5fb07b82b2f5a4466058b876ab72bb2 # v5.3.0
       with:
         dotnet-version: '10.0.x'    
     - name: publish nuget 

--- a/.github/workflows/staleissues.yml
+++ b/.github/workflows/staleissues.yml
@@ -6,8 +6,12 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
-    - uses: actions/stale@v10
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days'

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,70 @@
+# Security Policy
+
+The PnP Core SDK is an open-source, community-maintained library (`PnP.Core`,
+`PnP.Core.Auth`, `PnP.Core.Admin`) and is **not** a Microsoft-supported product.
+The maintainers take security seriously and appreciate responsible disclosure.
+
+## Supported Versions
+
+Security fixes are delivered in the latest stable release published to NuGet.
+We recommend always running the most recent stable version.
+
+| Package          | Supported            |
+| ---------------- | -------------------- |
+| Latest stable (1.16.x and newer) | ✅ Yes  |
+| Older releases   | ❌ No (upgrade to latest) |
+
+The SDK targets `.NET Standard 2.0`, `.NET 8.0`, `.NET 9.0`, and `.NET 10.0`.
+Keep your runtime patched, as some security fixes come from the underlying
+.NET runtime and dependencies (e.g. MSAL / `Microsoft.Identity.Client`).
+
+## Reporting a Vulnerability
+
+**Please do NOT open a public GitHub issue for security vulnerabilities.**
+
+Instead, report privately using one of the following:
+
+1. **Preferred — GitHub Private Vulnerability Reporting:** open a report via the
+   repository's **Security → Report a vulnerability** tab 
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact.
+- The affected package(s) and version(s).
+- Steps to reproduce or a proof-of-concept.
+- Any suggested remediation.
+
+### What to expect
+
+- **Acknowledgement** of your report as soon as the maintainers can triage it.
+- An assessment and, where confirmed, a coordinated fix in an upcoming release.
+- Credit in the release notes if you wish (let us know).
+
+Because this is a volunteer-maintained community project, there is no formal SLA,
+but we aim to handle valid reports promptly.
+
+## Scope
+
+This policy covers the SDK source code and the published NuGet packages
+(`PnP.Core`, `PnP.Core.Auth`, `PnP.Core.Admin`). Issues in Microsoft 365 services,
+Microsoft Graph, SharePoint Online, or the .NET runtime should be reported to
+Microsoft (e.g. the [Microsoft Security Response Center](https://msrc.microsoft.com/)).
+
+## Consumer Hardening Guidance
+
+If you build applications on top of the PnP Core SDK, we recommend:
+
+- **Least privilege:** request the narrowest Microsoft Entra (Azure AD) permission
+  scopes your app needs. Avoid `*.FullControl.All` / app-only Sites.FullControl
+  unless strictly required — a compromised app inherits the SDK's granted scopes.
+- **Protect credentials:** prefer certificate-based or managed-identity auth over
+  client secrets / username+password flows. Store secrets in a vault, never in
+  source or config committed to a repo.
+- **Validate untrusted input:** sanitize/encode any user-supplied values (site URLs,
+  file names, list/field values, search queries) before passing them to SDK calls.
+- **Pin and update dependencies:** keep `PnP.Core*` and transitive dependencies
+  (especially MSAL) up to date; subscribe to release notes.
+- **Verify package integrity:** consume packages only from the official NuGet feed
+  (nuget.org, authors `PnP`), and consider NuGet package signature verification.
+- **Don't log tokens:** ensure your logging configuration does not capture access
+  tokens, refresh tokens, secrets, or full request/response bodies.


### PR DESCRIPTION
## 🎯 Aim

The aim of this PR is to improve repo security by:

- Adds a missing SECURITY policy file that explains how repo/product vulnerabilities should be reported in private rather than in public
- Adds dependabot 7 days cooldown to prevent rapid supply chain attacks
- Adds timeouts to all workflows
- Updates the build and test workflow to run tests from PR branch - till now it checked tests that were on dev branch for every PR
- Adds minimal GH token permissions to each workflow
- GH actions pinned by SHA tag to commit not by version tag