### PR TITLE
Rename sovereign cloud environments in CloudManager and Microsoft365Environment

### DIFF
--- a/src/sdk/PnP.Core.Test/Misc/CloudManagerTests.cs
+++ b/src/sdk/PnP.Core.Test/Misc/CloudManagerTests.cs
@@ -21,8 +21,9 @@ namespace PnP.Core.Test.Misc
 
         [TestMethod()]
         [DataRow("https://bertonline.sharepoint.com/sites/prov-2", Microsoft365Environment.Production)]
-        [DataRow("https://bertonline.sharepoint.de/sites/prov-2", Microsoft365Environment.GovDe)]
-        [DataRow("https://bertonline.sharepoint.fr/sites/prov-2", Microsoft365Environment.GovFr)]
+        [DataRow("https://bertonline.sharepoint.de/sites/prov-2", Microsoft365Environment.DelosCloud)]
+        [DataRow("https://bertonline.sharepoint.fr/sites/prov-2", Microsoft365Environment.BleuCloud)]
+        [DataRow("https://bertonline.sharepoint.sg/sites/prov-2", Microsoft365Environment.GovSGCloud)]
         [DataRow("https://bertonline.sharepoint.cn/sites/prov-2", Microsoft365Environment.China)]
         [DataRow("https://bertonline.sharepoint.us/sites/prov-2", Microsoft365Environment.USGovernment)]
         [DataRow("https://bertonline.sharepoint.oops/sites/prov-2", Microsoft365Environment.Production)]
@@ -38,9 +39,9 @@ namespace PnP.Core.Test.Misc
         [DataRow("microsoftgraph.chinacloudapi.cn", Microsoft365Environment.China)]
         [DataRow("graph.microsoft.us", Microsoft365Environment.USGovernmentHigh)]
         [DataRow("dod-graph.microsoft.us", Microsoft365Environment.USGovernmentDoD)]
-        [DataRow("graph.svc.sovcloud.fr", Microsoft365Environment.GovFr)]
-        [DataRow("graph.svc.sovcloud.de", Microsoft365Environment.GovDe)]
-        [DataRow("graph.svc.sovcloud.sg", Microsoft365Environment.GovSg)]
+        [DataRow("graph.svc.sovcloud.fr", Microsoft365Environment.BleuCloud)]
+        [DataRow("graph.svc.sovcloud.de", Microsoft365Environment.DelosCloud)]
+        [DataRow("graph.svc.sovcloud.sg", Microsoft365Environment.GovSGCloud)]
         public void Microsoft365EnvironmentToGraph(string graph, Microsoft365Environment env)
         {
             Assert.AreEqual(graph, CloudManager.GetMicrosoftGraphAuthority(env));
@@ -53,9 +54,9 @@ namespace PnP.Core.Test.Misc
         [DataRow("login.chinacloudapi.cn", Microsoft365Environment.China)]
         [DataRow("login.microsoftonline.us", Microsoft365Environment.USGovernmentHigh)]
         [DataRow("login.microsoftonline.us", Microsoft365Environment.USGovernmentDoD)]
-        [DataRow("login.sovcloud-identity.fr", Microsoft365Environment.GovFr)]
-        [DataRow("login.sovcloud-identity.de", Microsoft365Environment.GovDe)]
-        [DataRow("login.sovcloud-identity.sg", Microsoft365Environment.GovSg)]
+        [DataRow("login.sovcloud-identity.fr", Microsoft365Environment.BleuCloud)]
+        [DataRow("login.sovcloud-identity.de", Microsoft365Environment.DelosCloud)]
+        [DataRow("login.sovcloud-identity.sg", Microsoft365Environment.GovSGCloud)]
         public void Microsoft365EnvironmentToAzureADLogin(string azureADLogin, Microsoft365Environment env)
         {
             Assert.AreEqual(azureADLogin, CloudManager.GetAzureADLoginAuthority(env));
@@ -89,13 +90,13 @@ namespace PnP.Core.Test.Misc
                 context.Environment = Microsoft365Environment.USGovernmentDoD;
                 Assert.AreEqual(CloudManager.GetGraphBaseUri(context), new Uri($"https://dod-graph.microsoft.us"));
 
-                context.Environment = Microsoft365Environment.GovFr;
+                context.Environment = Microsoft365Environment.BleuCloud;
                 Assert.AreEqual(CloudManager.GetGraphBaseUri(context), new Uri($"https://graph.svc.sovcloud.fr"));
 
-                context.Environment = Microsoft365Environment.GovDe;
+                context.Environment = Microsoft365Environment.DelosCloud;
                 Assert.AreEqual(CloudManager.GetGraphBaseUri(context), new Uri($"https://graph.svc.sovcloud.de"));
 
-                context.Environment = Microsoft365Environment.GovSg;
+                context.Environment = Microsoft365Environment.GovSGCloud;
                 Assert.AreEqual(CloudManager.GetGraphBaseUri(context), new Uri($"https://graph.svc.sovcloud.sg"));
 
                 context.Environment = Microsoft365Environment.Custom;

--- a/src/sdk/PnP.Core/Services/Core/CloudManager.cs
+++ b/src/sdk/PnP.Core/Services/Core/CloudManager.cs
@@ -12,10 +12,10 @@ namespace PnP.Core.Services
             {
                 "com" => Microsoft365Environment.Production,
                 "us" => Microsoft365Environment.USGovernment,
-                "de" => Microsoft365Environment.GovDe,
+                "de" => Microsoft365Environment.DelosCloud,
                 "cn" => Microsoft365Environment.China,
-                "fr" => Microsoft365Environment.GovFr,
-                "sg" => Microsoft365Environment.GovSg,                
+                "fr" => Microsoft365Environment.BleuCloud,
+                "sg" => Microsoft365Environment.GovSGCloud,                
                 _ => Microsoft365Environment.Production,
             };
         }
@@ -36,9 +36,9 @@ namespace PnP.Core.Services
                 Microsoft365Environment.USGovernmentHigh => "graph.microsoft.us",
                 Microsoft365Environment.USGovernmentDoD => "dod-graph.microsoft.us",                
                 Microsoft365Environment.China => "microsoftgraph.chinacloudapi.cn",
-                Microsoft365Environment.GovFr => "graph.svc.sovcloud.fr",
-                Microsoft365Environment.GovDe => "graph.svc.sovcloud.de",
-                Microsoft365Environment.GovSg => "graph.svc.sovcloud.sg",
+                Microsoft365Environment.BleuCloud => "graph.svc.sovcloud.fr",
+                Microsoft365Environment.DelosCloud => "graph.svc.sovcloud.de",
+                Microsoft365Environment.GovSGCloud => "graph.svc.sovcloud.sg",
                 _ => "graph.microsoft.com"
             };
         }
@@ -59,9 +59,9 @@ namespace PnP.Core.Services
                 Microsoft365Environment.USGovernmentHigh => "login.microsoftonline.us",
                 Microsoft365Environment.USGovernmentDoD => "login.microsoftonline.us",                
                 Microsoft365Environment.China => "login.chinacloudapi.cn",
-                Microsoft365Environment.GovFr => "login.sovcloud-identity.fr",
-                Microsoft365Environment.GovDe => "login.sovcloud-identity.de",
-                Microsoft365Environment.GovSg => "login.sovcloud-identity.sg",
+                Microsoft365Environment.BleuCloud => "login.sovcloud-identity.fr",
+                Microsoft365Environment.DelosCloud => "login.sovcloud-identity.de",
+                Microsoft365Environment.GovSGCloud => "login.sovcloud-identity.sg",
                 _ => "login.microsoftonline.com"
             };
         }

--- a/src/sdk/PnP.Core/Services/Core/Microsoft365Environment.cs
+++ b/src/sdk/PnP.Core/Services/Core/Microsoft365Environment.cs
@@ -38,17 +38,17 @@
         /// <summary>
         /// French sovereign cloud environment. A joint venture between Orange and Capgemini, designed to meet SecNumCloud requirements. See https://learn.microsoft.com/en-us/industry/sovereign-cloud/national-partner-clouds/overview-national-partner-clouds
         /// </summary>
-        GovFr = 7,
+        BleuCloud = 7,
 
         /// <summary>
-        /// Represents the GovDe Cloud environment option. Operated by an SAP subsidiary and aligned with German Cloud Platform Requirements. See https://learn.microsoft.com/en-us/industry/sovereign-cloud/national-partner-clouds/overview-national-partner-clouds
+        /// Represents the DelosCloud Cloud environment option. Operated by an SAP subsidiary and aligned with German Cloud Platform Requirements. See https://learn.microsoft.com/en-us/industry/sovereign-cloud/national-partner-clouds/overview-national-partner-clouds
         /// </summary>
-        GovDe = 8,
+        DelosCloud = 8,
 
         /// <summary>
-        /// Represents the GovSG Cloud environment option. Operated by a Singaporean government-owned company and aligned with Singapore's Sovereign Cloud Framework. See https://learn.microsoft.com/en-us/industry/sovereign-cloud/national-partner-clouds/overview-national-partner-clouds
+        /// Represents the GovSGCloud Cloud environment option. Operated by a Singaporean government-owned company and aligned with Singapore's Sovereign Cloud Framework. See https://learn.microsoft.com/en-us/industry/sovereign-cloud/national-partner-clouds/overview-national-partner-clouds
         /// </summary>
-        GovSg = 9,
+        GovSGCloud = 9,
 
         /// <summary>
         /// Custom cloud configuration, specify the endpoints manually


### PR DESCRIPTION
Renaming it align with 1P tooling and avoid confusion