### PR TITLE
Updates release workflows to use nuget trusted publishing

### DIFF
--- a/.github/workflows/cleannightlynuget.yml
+++ b/.github/workflows/cleannightlynuget.yml
@@ -14,6 +14,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+      id-token: write   # required for GitHub OIDC token issuance (trusted publishing)
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -25,9 +26,14 @@ jobs:
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: '10.0.x'
+    - name: NuGet login (OIDC → temporary API key)
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.2.0
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: Unlist nightly nuget packages
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
       shell: pwsh
       run: |
         ./build/unlist-nightly.ps1

--- a/.github/workflows/nightlynuget_dev.yml
+++ b/.github/workflows/nightlynuget_dev.yml
@@ -12,6 +12,7 @@ jobs:
     timeout-minutes: 40
     permissions:
       contents: read
+      id-token: write   # required for GitHub OIDC token issuance (trusted publishing)
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -21,9 +22,14 @@ jobs:
       uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: '10.0.x'    
+    - name: NuGet login (OIDC → temporary API key)
+      uses: NuGet/login@d22cc5f58ff5b88bf9bd452535b4335137e24544 # v1.2.0
+      id: login
+      with:
+        user: ${{ secrets.NUGET_USER }}
     - name: publish nuget 
       env:
-        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        NUGET_API_KEY: ${{ steps.login.outputs.NUGET_API_KEY }}
       shell: pwsh
       run: |
         ./build/publish-nightly.ps1


### PR DESCRIPTION
## 🎯 Aim

The aim is to refactor the current workflows that interact with nuget.org to use short-lived tokens based on trusted publishing policies 