### PR TITLE
Expose list item validation error details

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/ListItemTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/ListItemTests.cs
@@ -303,10 +303,15 @@ namespace PnP.Core.Test.SharePoint
                     await list.Items.AddBatchAsync(propItem);
                 }
 
-                await Assert.ThrowsExceptionAsync<SharePointRestServiceException>(async () =>
+                var exception = await Assert.ThrowsExceptionAsync<SharePointRestServiceException>(async () =>
                 {
                     await context.ExecuteAsync();
                 });
+
+                var error = exception.Error as SharePointRestError;
+                Assert.IsNotNull(error);
+                Assert.AreEqual(0, error.ServerErrorCode);
+                Assert.AreEqual("abc", error.Message);
 
                 await list.DeleteAsync();
             }
@@ -354,6 +359,10 @@ namespace PnP.Core.Test.SharePoint
                     var errors = await context.ExecuteAsync(false);
 
                     Assert.IsTrue(errors.Count == 2);
+                    var error = errors[0].Error as SharePointRestError;
+                    Assert.IsNotNull(error);
+                    Assert.AreEqual(0, error.ServerErrorCode);
+                    Assert.AreEqual("abc", error.Message);
                 }
                 finally
                 {

--- a/src/sdk/PnP.Core.Test/SharePoint/ListItemTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/ListItemTests.cs
@@ -416,6 +416,10 @@ namespace PnP.Core.Test.SharePoint
                     var errors = await context.ExecuteAsync(batch, false);
 
                     Assert.IsTrue(errors.Count == 2);
+                    var error = errors[0].Error as SharePointRestError;
+                    Assert.IsNotNull(error);
+                    Assert.AreEqual(0, error.ServerErrorCode);
+                    Assert.AreEqual("abc", error.Message);
                 }
                 finally
                 {

--- a/src/sdk/PnP.Core/Exceptions/SharePointRestError.cs
+++ b/src/sdk/PnP.Core/Exceptions/SharePointRestError.cs
@@ -48,6 +48,12 @@ namespace PnP.Core
             }
         }
 
+        internal SharePointRestError(ErrorType type, int httpResponseCode, long serverErrorCode, string message) : base(type, httpResponseCode)
+        {
+            ServerErrorCode = serverErrorCode;
+            Message = message;
+        }
+
         /// <summary>
         /// SharePoint server error code
         /// </summary>

--- a/src/sdk/PnP.Core/Exceptions/SharePointRestServiceException.cs
+++ b/src/sdk/PnP.Core/Exceptions/SharePointRestServiceException.cs
@@ -17,6 +17,11 @@ namespace PnP.Core
         {
         }
 
+        internal SharePointRestServiceException(string message, SharePointRestError error) : base(message)
+        {
+            Error = error;
+        }
+
         internal SharePointRestServiceException()
         {
         }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
@@ -196,8 +196,13 @@ namespace PnP.Core.Model.SharePoint
                 var errorMessage = field.TryGetProperty("ErrorMessage", out JsonElement errorMessageProperty)
                     && errorMessageProperty.ValueKind == JsonValueKind.String
                     ? errorMessageProperty.GetString()
-                    : string.Format(PnPCoreResources.Exception_ListItemAdd_WrongInternalFieldName, fieldName);
+                    : null;
+                if (string.IsNullOrEmpty(errorMessage))
+                {
+                    errorMessage = string.Format(PnPCoreResources.Exception_ListItemAdd_WrongInternalFieldName, fieldName);
+                }
                 var errorCode = field.TryGetProperty("ErrorCode", out JsonElement errorCodeProperty)
+                    && errorCodeProperty.ValueKind == JsonValueKind.Number
                     && errorCodeProperty.TryGetInt64(out long parsedErrorCode) ? parsedErrorCode : 0;
                 var error = new SharePointRestError(ErrorType.SharePointRestServiceError, (int)System.Net.HttpStatusCode.OK, errorCode, errorMessage);
 
@@ -218,10 +223,7 @@ namespace PnP.Core.Model.SharePoint
 
                 if (!handled)
                 {
-                    throw new SharePointRestServiceException(errorMessage)
-                    {
-                        Error = error
-                    };
+                    throw new SharePointRestServiceException(errorMessage, error);
                 }
             }
 

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/ListItem.cs
@@ -193,6 +193,14 @@ namespace PnP.Core.Model.SharePoint
             // not be added which is indicated via the HasException property on the field. If so then throw an error.
             if (field.TryGetProperty("HasException", out JsonElement hasExceptionProperty) && hasExceptionProperty.GetBoolean() == true)
             {
+                var errorMessage = field.TryGetProperty("ErrorMessage", out JsonElement errorMessageProperty)
+                    && errorMessageProperty.ValueKind == JsonValueKind.String
+                    ? errorMessageProperty.GetString()
+                    : string.Format(PnPCoreResources.Exception_ListItemAdd_WrongInternalFieldName, fieldName);
+                var errorCode = field.TryGetProperty("ErrorCode", out JsonElement errorCodeProperty)
+                    && errorCodeProperty.TryGetInt64(out long parsedErrorCode) ? parsedErrorCode : 0;
+                var error = new SharePointRestError(ErrorType.SharePointRestServiceError, (int)System.Net.HttpStatusCode.OK, errorCode, errorMessage);
+
                 bool handled = false;
                 if (batchRequestId != Guid.Empty)
                 {
@@ -203,14 +211,17 @@ namespace PnP.Core.Model.SharePoint
                         actualBatch.AddBatchResult(actualBatch.GetRequest(batchRequestId),
                                                  System.Net.HttpStatusCode.OK,
                                                  value.ToString(),
-                                                 new SharePointRestError(ErrorType.SharePointRestServiceError, (int)System.Net.HttpStatusCode.OK, string.Format(PnPCoreResources.Exception_ListItemAdd_WrongInternalFieldName, fieldName)));
+                                                 error);
                         handled = true;
                     }
                 }
 
                 if (!handled)
                 {
-                    throw new SharePointRestServiceException(string.Format(PnPCoreResources.Exception_ListItemAdd_WrongInternalFieldName, fieldName));
+                    throw new SharePointRestServiceException(errorMessage)
+                    {
+                        Error = error
+                    };
                 }
             }
 


### PR DESCRIPTION
## Aim

Expose the SharePoint error code and message returned by list item validation.

## What was changed

`SharePointRestError` now receives those details for both thrown exceptions and non-throwing batch results. Existing list item tests cover both paths.

## Related issue

Closes #1764
