### PR TITLE
Add SetViewXml API for list views

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/ListViewTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/ListViewTests.cs
@@ -398,5 +398,20 @@ namespace PnP.Core.Test.SharePoint
 
             }
         }
+
+        [TestMethod]
+        public void SetViewXmlApiCall()
+        {
+            const string viewXml = "<View><ColumnWidth><FieldRef Name=\"Modified\" width=\"370\" /></ColumnWidth></View>";
+
+            var apiCall = View.GetSetViewXmlApiCall(viewXml);
+
+            Assert.AreEqual(PnP.Core.Services.ApiType.SPORest, apiCall.Type);
+            Assert.AreEqual("_api/web/lists/getbyid(guid'{Parent.Id}')/Views(guid'{Id}')/SetViewXml", apiCall.Request);
+
+            using var body = System.Text.Json.JsonDocument.Parse(apiCall.JsonBody);
+            Assert.AreEqual(1, body.RootElement.EnumerateObject().Count());
+            Assert.AreEqual(viewXml, body.RootElement.GetProperty("viewXml").GetString());
+        }
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/View.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/View.cs
@@ -181,6 +181,29 @@ namespace PnP.Core.Model.SharePoint
 
         #region Extension Methods
 
+        public async Task SetViewXmlAsync(string viewXml)
+        {
+            var apiCall = GetSetViewXmlApiCall(viewXml);
+            await RequestAsync(apiCall, HttpMethod.Post).ConfigureAwait(false);
+        }
+
+        internal static ApiCall GetSetViewXmlApiCall(string viewXml)
+        {
+            var body = new
+            {
+                viewXml
+            };
+
+            var bodyString = JsonSerializer.Serialize(body);
+
+            return new ApiCall("_api/web/lists/getbyid(guid'{Parent.Id}')/Views(guid'{Id}')/SetViewXml", ApiType.SPORest, bodyString);
+        }
+
+        public void SetViewXml(string viewXml)
+        {
+            SetViewXmlAsync(viewXml).GetAwaiter().GetResult();
+        }
+
         public async Task MoveViewFieldToAsync(string internalFieldName, int newOrder)
         {
             var apiCall = GetMoveViewFieldToApiCall(internalFieldName, newOrder);

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IView.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Public/IView.cs
@@ -255,6 +255,20 @@ namespace PnP.Core.Model.SharePoint
         #region Methods
 
         /// <summary>
+        /// Sets the XML schema for the current view
+        /// </summary>
+        /// <param name="viewXml">XML schema to apply to the view</param>
+        /// <returns></returns>
+        Task SetViewXmlAsync(string viewXml);
+
+        /// <summary>
+        /// Sets the XML schema for the current view
+        /// </summary>
+        /// <param name="viewXml">XML schema to apply to the view</param>
+        /// <returns></returns>
+        void SetViewXml(string viewXml);
+
+        /// <summary>
         /// Moves a view field to a new position in the view
         /// </summary>
         /// <param name="internalFieldName">Internal name of the view field to move</param>


### PR DESCRIPTION
Adds synchronous and asynchronous `SetViewXml` methods that use SharePoint's `SetViewXml` endpoint instead of the normal model update path. Includes a unit test for the request endpoint and serialized body.

Tests: focused regression and builds for netstandard2.0, net8.0, net9.0, and net10.0.

Closes #1596.
