### PR TITLE
Fix: #1763 - Web.NewPage() freezes application (GUI: WPF, WinFroms)

### DIFF
--- a/src/sdk/PnP.Core/QueryModel/Linq/QueryableExtensions.cs
+++ b/src/sdk/PnP.Core/QueryModel/Linq/QueryableExtensions.cs
@@ -450,7 +450,8 @@ namespace PnP.Core.QueryModel
             }
 
             var d = new Dictionary<TKey, TElement>(comparer);
-            await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken))
+            var elements = source.AsAsyncEnumerable().ConfigureAwait(false);
+            await foreach (var element in elements.WithCancellation(cancellationToken))
             {
                 d.Add(keySelector(element), elementSelector(element));
             }
@@ -492,7 +493,8 @@ namespace PnP.Core.QueryModel
                 throw new ArgumentNullException(nameof(action));
             }
 
-            await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken))
+            var elements = source.AsAsyncEnumerable().ConfigureAwait(false);
+            await foreach (var element in elements.WithCancellation(cancellationToken))
             {
                 action(element);
             }
@@ -523,8 +525,9 @@ namespace PnP.Core.QueryModel
             this IQueryable<TSource> source,
             CancellationToken cancellationToken = default)
         {
-            var list = new List<TSource>();
-            await foreach (var element in source.AsAsyncEnumerable().WithCancellation(cancellationToken))
+            var list = new List<TSource>();            
+            var elements = source.AsAsyncEnumerable().ConfigureAwait(false);
+            await foreach (var element in elements.WithCancellation(cancellationToken))
             {
                 list.Add(element);
             }


### PR DESCRIPTION
Fix: #1763 - Web.NewPage() freezes application (GUI: WPF, WinFroms)

The default behavior of .WithCancellation() is to set the continueOnCapturedContext = true which is the same as calling ConfigureAwait(**true**)) before .WithCancellation().

https://github.com/dotnet/corert/blob/c6af4cfc8b625851b91823d9be746c4f7abdc667/src/System.Private.CoreLib/shared/System/Threading/Tasks/TaskAsyncEnumerableExtensions.cs#L33

The usage of .WithCancellation() with in Windows GUI (WPF, WinForms, ...) will lead to some blocking / deadlock.
[Async/Await - Best Practices in Asynchronous Programming - Configure Context](https://learn.microsoft.com/en-us/archive/msdn-magazine/2013/march/async-await-best-practices-in-asynchronous-programming#configure-context)

A **.ConfigureAwait(false)** call before WithCancellation will solve the issue.