### PR TITLE
Scope ISharePointUser.Groups to the groups the user belongs to

### DIFF
--- a/src/sdk/PnP.Core.Test/Security/SharePointGroupTests.cs
+++ b/src/sdk/PnP.Core.Test/Security/SharePointGroupTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PnP.Core.Model;
 using PnP.Core.Model.Security;
 using PnP.Core.QueryModel;
 using PnP.Core.Test.Utilities;
@@ -475,6 +476,25 @@ namespace PnP.Core.Test.Security
                         await siteGroup.DeleteAsync();
                     }
                 }
+            }
+        }
+
+        [TestMethod]
+        public async Task SharePointGroupEndpointDependsOnParent()
+        {
+            // Offline test: mocked responses are replayed per request sequence, so only asserting on the
+            // generated endpoint catches a group collection that is loaded from the wrong scope
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var user = new SharePointUser { PnPContext = context, Parent = context.Web, Id = 12 };
+
+                var fromWeb = EntityManager.GetClassInfo<ISharePointGroup>(typeof(SharePointGroup), null, parent: context.Web as IDataModelParent);
+                var fromSite = EntityManager.GetClassInfo<ISharePointGroup>(typeof(SharePointGroup), null, parent: context.Site as IDataModelParent);
+                var fromUser = EntityManager.GetClassInfo<ISharePointGroup>(typeof(SharePointGroup), null, parent: user);
+
+                Assert.AreEqual("_api/Web/SiteGroups", fromWeb.SharePointLinqGet);
+                Assert.AreEqual("_api/Web/SiteGroups", fromSite.SharePointLinqGet);
+                Assert.AreEqual("_api/Web/GetUserById({Parent.Id})/Groups", fromUser.SharePointLinqGet);
             }
         }
     }

--- a/src/sdk/PnP.Core/Model/Security/Internal/SharePointGroup.cs
+++ b/src/sdk/PnP.Core/Model/Security/Internal/SharePointGroup.cs
@@ -1,4 +1,5 @@
-﻿using PnP.Core.QueryModel;
+﻿using PnP.Core.Model.SharePoint;
+using PnP.Core.QueryModel;
 using PnP.Core.Services;
 using PnP.Core.Utilities;
 using System;
@@ -9,7 +10,9 @@ using System.Threading.Tasks;
 
 namespace PnP.Core.Model.Security
 {
-    [SharePointType("SP.Group", Uri = "_api/Web/sitegroups/getbyid({Id})", LinqGet = "_api/Web/SiteGroups", Delete = "_api/Web/SiteGroups/RemoveById({Id})")]
+    [SharePointType("SP.Group", Target = typeof(Web), Uri = "_api/Web/sitegroups/getbyid({Id})", LinqGet = "_api/Web/SiteGroups", Delete = "_api/Web/SiteGroups/RemoveById({Id})")]
+    [SharePointType("SP.Group", Target = typeof(Site), Uri = "_api/Web/sitegroups/getbyid({Id})", LinqGet = "_api/Web/SiteGroups", Delete = "_api/Web/SiteGroups/RemoveById({Id})")]
+    [SharePointType("SP.Group", Target = typeof(SharePointUser), Uri = "_api/Web/sitegroups/getbyid({Id})", LinqGet = "_api/Web/GetUserById({Parent.Id})/Groups", Delete = "_api/Web/SiteGroups/RemoveById({Id})")]
     internal sealed class SharePointGroup : BaseDataModel<ISharePointGroup>, ISharePointGroup
     {
         #region Construction


### PR DESCRIPTION
Fixes #1630

### What is happening

`ISharePointUser.Groups` returns every group in the site, whether or not the user is a member of any of them.

`SharePointGroup` carried a single `[SharePointType("SP.Group", ...)]` mapping with `LinqGet = "_api/Web/SiteGroups"`. That mapping is used no matter which model the group collection hangs off, so `user.Groups` issued the site wide request and the user was never part of the query.

### Repro

Test site with 5 site groups. `shaunvermaak@ittelligencedev.onmicrosoft.com` was added to `PnPCore1630 Member Group` and to nothing else, then `user.Groups.ToListAsync()` was called.

```csharp
var user = await context.Web.EnsureUserAsync(upn);
var userGroups = await user.Groups.ToListAsync();
```

Before - all 5 site groups come back, including one the user is explicitly not a member of:

![before](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1630/1630-before.png)

After - only the group the user actually belongs to:

![after](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1630/1630-after.png)

### The fix

`SP.Group` is now mapped per parent type, with the `SharePointUser` mapping pointing at the user scoped endpoint:

```csharp
[SharePointType("SP.Group", Target = typeof(Web), ... LinqGet = "_api/Web/SiteGroups", ...)]
[SharePointType("SP.Group", Target = typeof(Site), ... LinqGet = "_api/Web/SiteGroups", ...)]
[SharePointType("SP.Group", Target = typeof(SharePointUser), ... LinqGet = "_api/Web/GetUserById({Parent.Id})/Groups", ...)]
```

The explicit `Web` and `Site` mappings are required, not cosmetic. `EntityInfo` only resolves a mapping by exact parent match once a model carries more than one `SharePointType` attribute, so leaving the original attribute untargeted would have broken `Web.SiteGroups`, `Web.Associated*Group` and `Site.HubSiteSynchronizableVisitorGroup`. This mirrors how `SP.User`, `SP.Field` and `SP.ContentType` are already mapped.

`Uri`, `Get`, `Update` and `Delete` stay on `_api/Web/sitegroups/...` for every parent, so only the enumeration scope changes.

### Tests

Added `SharePointGroupTests.SharePointGroupEndpointDependsOnParent`, an offline test asserting the resolved endpoint for each of the three parent types. A mocked test would not have caught this: mock responses are replayed by request sequence, so the wrong URL still replays the right payload.

The new test fails on `dev` and passes with this change.

Full offline test suite before and after this change: 8 identical pre-existing failures (timezone, access token, clone and page publish tests), no new failures.

No CHANGELOG entry included.
