### PR TITLE
Read a sub folder from its own endpoint instead of its parent's

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/FoldersTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/FoldersTests.cs
@@ -1486,5 +1486,25 @@ namespace PnP.Core.Test.SharePoint
         }
 
         #endregion
+
+        #region Endpoint mapping
+
+        [TestMethod]
+        public async Task SubFolderIsReadFromItsOwnEndpoint()
+        {
+            // Offline test: mocked responses are replayed per request sequence, so only asserting on the
+            // generated endpoint catches a sub folder that is read from its parent's url
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var parentFolder = new Folder { PnPContext = context, Parent = context.Web };
+
+                var entityInfo = EntityManager.GetClassInfo<IFolder>(typeof(Folder), null, parent: parentFolder);
+
+                Assert.AreEqual("_api/Web/getFolderById('{Id}')", entityInfo.SharePointGet);
+                Assert.AreEqual("_api/Web/getFolderById('{Parent.Id}')/Folders", entityInfo.SharePointLinqGet);
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Folder.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Core/Internal/Folder.cs
@@ -19,11 +19,13 @@ namespace PnP.Core.Model.SharePoint
     /// Folder class, write your custom code here
     /// </summary>
     [SharePointType("SP.Folder", Target = typeof(Web), Uri = "_api/Web/getFolderById('{Id}')", LinqGet = "_api/Web/Folders")]
-    [SharePointType("SP.Folder", Target = typeof(Folder), Uri = "_api/Web/getFolderById('{Id}')", Get = "_api/Web/getFolderById('{Parent.Id}')", LinqGet = "_api/Web/getFolderById('{Parent.Id}')/Folders")]
+    [SharePointType("SP.Folder", Target = typeof(Folder), Uri = "_api/Web/getFolderById('{Id}')", LinqGet = "_api/Web/getFolderById('{Parent.Id}')/Folders")]
     [SharePointType("SP.Folder", Target = typeof(List), Uri = "_api/Web/Lists(guid'{Parent.Id}')/rootFolder", LinqGet = "_api/Web/Lists(guid'{Parent.Id}')/Folders")]
     [SharePointType("SP.Folder", Target = typeof(ListItem), Uri = "_api/Web/Lists(guid'{List.Id}')/Items({Parent.Id})/Folder")]
     internal sealed class Folder : BaseDataModel<IFolder>, IFolder
     {
+        private const string ParentFolderApiCall = "_api/Web/getFolderById('{Parent.Id}')";
+
         #region Construction
         public Folder()
         {
@@ -42,8 +44,12 @@ namespace PnP.Core.Model.SharePoint
                 //throw new ClientException(ErrorType.Unsupported, OnPCoreResources.Exception_Unsupported_AddingContentTypeToList);
                 //}
 
+                // A folder is added to its container, so when the container is a folder the add call has to
+                // target the parent folder. The Get of a folder points to the folder itself.
+                string containerApiCall = entity.Target == typeof(Folder) ? ParentFolderApiCall : entity.SharePointGet;
+
                 string encodedPath = WebUtility.UrlEncode(Name.Replace("'", "''").Replace("%20", " ")).Replace("+", "%20");
-                return new ApiCall($"{entity.SharePointGet}/Folders/AddUsingPath(decodedurl='{encodedPath}')", ApiType.SPORest);
+                return new ApiCall($"{containerApiCall}/Folders/AddUsingPath(decodedurl='{encodedPath}')", ApiType.SPORest);
             };
         }
         #endregion


### PR DESCRIPTION
Fixes #1586

### What is happening

The `SP.Folder` mapping for a folder whose parent is a folder overrides `Get`:

```csharp
[SharePointType("SP.Folder", Target = typeof(Folder), Uri = "_api/Web/getFolderById('{Id}')", Get = "_api/Web/getFolderById('{Parent.Id}')", ...)]
```

`Get` is what every non LINQ read of the model resolves to, so reading a sub folder actually requested its **parent's** url. `await subFolder.LoadAsync(p => p.Folders, p => p.Files)` therefore returned the parent folder's children, and those are the items `AsRequested()` hands back. The `Folders` and `Files` queryables were unaffected because they resolve `LinqGet`, which is correct - that is exactly the discrepancy reported in the issue.

It is not limited to collections. Loading any single property on a sub folder returns the parent's value, as the second block in the screenshots shows.

### Repro

Library `PnPCore1586` with the structure from the issue:

```
Top-level file.txt
Top-level Folder/
    Nested file.txt
    Nested Folder/
```

```csharp
await root.LoadAsync(p => p.Folders, p => p.Files);
IFolder top = root.Folders.AsRequested().First(f => f.Name == "Top-level Folder");
await top.LoadAsync(p => p.Folders, p => p.Files);
// top.Folders.AsRequested() / top.Files.AsRequested()
```

Before - the library root's children come back, and `ServerRelativeUrl` on a freshly created sub folder reads back the parent's url:

![before](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1586/1586-before.png)

After:

![after](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1586/1586-after.png)

### The fix

`Get` is dropped from that mapping so it falls back to `Uri`, `_api/Web/getFolderById('{Id}')`.

`AddApiCallHandler` was the one consumer that depended on `Get` pointing at the parent, since a folder is created through its container: `{container}/Folders/AddUsingPath(...)`. It now builds that parent url itself when the target is a folder, so adding folders is unchanged. The screenshots include an add plus read-back of the new folder to confirm both halves.

`SP.File` with `Target = typeof(Folder)` already had no `Get` override, so files were only affected through the expand on the folder read.

### Tests

Added `FoldersTests.SubFolderIsReadFromItsOwnEndpoint`, an offline test pinning `Get` and `LinqGet` for the folder-in-folder mapping. A mocked test cannot catch this: mock responses are replayed by request sequence, so the wrong url still replays the right payload.

The new test fails on `dev` and passes with this change.

Full offline test suite: 8 pre-existing failures (timezone, access token, clone and page publish tests) before and after, no new failures.

No CHANGELOG entry included.
