### PR TITLE
Allow updating a web part hosted in a one column full width section

### DIFF
--- a/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
+++ b/src/sdk/PnP.Core.Test/SharePoint/PagesTests.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net;
 using System.Reflection;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -3631,6 +3632,87 @@ namespace PnP.Core.Test.SharePoint
             string input = "data-config-json=\\\"{\\\"key\\\":\\\"value\\\"}\\\"";
             string result = CallEscapeJsonValues(input);
             Assert.AreEqual(input, result);
+        }
+        #endregion
+
+        #region Full width sections
+        // A custom web part declares full bleed support in its manifest, but the manifest is not part of the page
+        // markup. These offline tests cover the two other ways such a web part can be recognized as full bleed
+        // capable, both needed to update a custom web part living in a one column full width section.
+
+        [TestMethod]
+        public async Task IsFullWidthPropertyMakesAWebPartFullBleedCapable()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var page = new Page(context, null, null);
+                page.AddSection(CanvasSectionTemplate.OneColumnFullWidth, 1);
+
+                var webPart = page.NewWebPart() as PageWebPart;
+                webPart.WebPartId = customWebPartId;
+                webPart.PropertiesJson = "{\"isFullWidth\": true}";
+
+                Assert.IsTrue(webPart.SupportsFullBleed);
+
+                page.AddControl(webPart, page.Sections[0]);
+
+                // Throws when the isFullWidth property is not honored
+                Assert.IsTrue(webPart.ToHtml(1).Contains(customWebPartId));
+            }
+        }
+
+        [TestMethod]
+        public async Task WebPartLoadedFromAFullWidthSectionStaysFullBleedCapable()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var page = new Page(context, null, null);
+                LoadFromHtml(page, FullWidthSectionPageHtml());
+
+                var webPart = page.Controls.Cast<PageWebPart>().Single();
+                Assert.AreEqual(CanvasSectionTemplate.OneColumnFullWidth, webPart.Section.Type);
+                Assert.IsTrue(webPart.SupportsFullBleed);
+
+                // Throws when a web part SharePoint stored in a full width section cannot be written back
+                Assert.IsTrue(webPart.ToHtml(1).Contains(customWebPartId));
+            }
+        }
+
+        private const string customWebPartId = "7f1fb168-1990-4bbc-b283-8386d64d1878";
+
+        private static void LoadFromHtml(Page page, string html)
+        {
+            var method = typeof(Page).GetMethod("LoadFromHtml", BindingFlags.NonPublic | BindingFlags.Instance);
+            method.Invoke(page, new object[] { html, null });
+        }
+
+        private static string FullWidthSectionPageHtml()
+        {
+            string controlData = JsonSerializer.Serialize(new
+            {
+                controlType = 3,
+                id = "d1a2f0bb-2b0f-4a29-9b12-64d1e0f3b7c5",
+                webPartId = customWebPartId,
+                // Section factor 0 is how SharePoint persists a one column full width section
+                position = new { zoneIndex = 1, sectionIndex = 1, sectionFactor = 0, controlIndex = 1 }
+            });
+
+            string webPartData = JsonSerializer.Serialize(new
+            {
+                id = customWebPartId,
+                instanceId = "d1a2f0bb-2b0f-4a29-9b12-64d1e0f3b7c5",
+                title = "Custom full bleed web part",
+                description = "",
+                dataVersion = "1.0",
+                properties = new { someProperty = "someValue" }
+            });
+
+            return $"<div data-sp-canvascontrol=\"\" data-sp-canvasdataversion=\"1.0\" " +
+                   $"data-sp-controldata=\"{WebUtility.HtmlEncode(controlData)}\">" +
+                   $"<div data-sp-webpart=\"\" data-sp-webpartdataversion=\"1.0\" " +
+                   $"data-sp-webpartdata=\"{WebUtility.HtmlEncode(webPartData)}\">" +
+                   $"<div data-sp-componentid=\"\">{customWebPartId}</div>" +
+                   $"<div data-sp-htmlproperties=\"\"></div></div></div>";
         }
         #endregion
 

--- a/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
+++ b/src/sdk/PnP.Core/Model/SharePoint/Pages/Internal/PageWebPart.cs
@@ -724,6 +724,14 @@ namespace PnP.Core.Model.SharePoint
                 }
             }
 
+            // A custom web part declares full bleed support in its manifest and that manifest is not part of the
+            // page markup. When SharePoint stored the web part in a one column full width section (section factor 0)
+            // then it does support full bleed, so keep it writable to that section.
+            if (!SupportsFullBleed && SpControlData?.Position != null && SpControlData.Position.SectionFactor == 0)
+            {
+                SupportsFullBleed = true;
+            }
+
             // Store the server processed content as that's needed for full fidelity
             if (wpJObject.TryGetProperty("serverProcessedContent", out JsonElement serverProcessedContent))
             {
@@ -878,6 +886,15 @@ namespace PnP.Core.Model.SharePoint
                 {
                     Properties = parsedJson;
                 }
+            }
+
+            // Setting isFullWidth is the documented way to tell the SDK that a web part can be hosted in a one
+            // column full width section, so honor it here as well and not only when reading a page
+            if (Properties.ValueKind == JsonValueKind.Object &&
+                Properties.TryGetProperty("isFullWidth", out JsonElement isFullWidth) &&
+                isFullWidth.ValueKind == JsonValueKind.True)
+            {
+                SupportsFullBleed = true;
             }
 
             if (wpConfigRoot.TryGetProperty("dataVersion", out JsonElement dataVersion))


### PR DESCRIPTION
Fixes #1801

### What is happening

`PageWebPart.ToHtml` refuses to write a control into a one column full width section unless `SupportsFullBleed` is set:

```csharp
if (Section.Type == CanvasSectionTemplate.OneColumnFullWidth)
{
    if (!SupportsFullBleed)
    {
        throw new ClientException(ErrorType.Unsupported, PnPCoreResources.Exception_Page_ControlNotAllowedInFullWidthSection);
    }
}
```

A custom web part declares full bleed support through `supportsFullBleed` in its **manifest**. `Import` reads that flag, so adding the web part works, but the manifest is not part of the page markup. When the page is read back `FromHtml` only recognizes a full bleed web part from the `isFullWidth` property or from a short list of first party web part ids, so `SupportsFullBleed` is false and the page can no longer be written. Every later update of that web part fails, which is the reported scenario.

Adding `isFullWidth` to `PropertiesJson`, as the issue and #387 suggest, does not help either: `SetPropertiesJson` never looked at that property, it is only read while parsing the page.

The check is driven by the section type, not by the position of the section, so a full width section further down the page behaves the same. The first section is simply the one that is full width on the pages in the report.

### Repro

Page `PnPCore1801.aspx` holding a web part that the SDK does not consider full bleed capable, stored by SharePoint in a one column full width section, then updated the way the issue does it:

```csharp
IPage page = (await context.Web.GetPagesAsync("PnPCore1801.aspx")).First();
IPageWebPart webPart = page.Controls.OfType<IPageWebPart>().First();

// new title plus "isFullWidth": true
webPart.PropertiesJson = WithProperties(webPart.PropertiesJson, stamp);

await page.SaveAsync("PnPCore1801.aspx");
```

Before:

![before](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1801/1801-before.png)

After:

![after](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1801/1801-after.png)

The page in the screenshots was set up with a first party web part that has no full bleed support in its manifest, since the test tenant has no SPFx solution deployed. The code path is the same one a custom web part takes, neither the manifest nor the page markup marks it as full width.

### The fix

Two additions in `PageWebPart`, both only ever turn `SupportsFullBleed` on:

- `SetPropertiesJson` honors `isFullWidth`, so the documented escape hatch works for a web part built in code as well as for one read from a page.

- `FromHtml` treats a web part that SharePoint stored with section factor 0 as full bleed capable. Section factor 0 is how a one column full width section is persisted, so the web part demonstrably supports full bleed and the SDK should not refuse to write it back to where it already lives.

Text controls are unaffected, `PageText` has its own check and keeps rejecting a full width section.

### Tests

Added two offline tests in `PagesTests`:

- `IsFullWidthPropertyMakesAWebPartFullBleedCapable`
- `WebPartLoadedFromAFullWidthSectionStaysFullBleedCapable`

Both assert the flag and then render the control, which throws when the guard still rejects it. A mocked test cannot catch this since mock responses are replayed by request sequence and the failure happens before any request is made.

Both tests fail on `dev` and pass with this change.

Full offline test suite: 8 pre-existing failures (timezone, access token, clone and page publish tests) before and after, no new failures.

No CHANGELOG entry included.
