### PR TITLE
Expose delete by id on IWeb.SiteUsers and IWeb.SiteGroups

### DIFF
--- a/src/sdk/PnP.Core.Test/Security/SharePointGroupTests.cs
+++ b/src/sdk/PnP.Core.Test/Security/SharePointGroupTests.cs
@@ -2,7 +2,9 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PnP.Core.Model.Security;
 using PnP.Core.QueryModel;
 using PnP.Core.Test.Utilities;
+using System;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PnP.Core.Test.Security
@@ -477,5 +479,35 @@ namespace PnP.Core.Test.Security
                 }
             }
         }
+
+        [TestMethod]
+        public async Task DeleteSiteGroupByIdGeneratesTheRemoveByIdCall()
+        {
+            // Offline by design, see the note on the user equivalent in UserTests
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var batch = context.NewBatch();
+
+                await context.Web.SiteGroups.DeleteByIdBatchAsync(batch, 12);
+
+                Assert.AreEqual(1, batch.Requests.Count);
+                var request = batch.Requests.First().Value;
+                Assert.AreEqual(HttpMethod.Delete, request.Method);
+                Assert.IsTrue(request.ApiCall.Request.EndsWith("/_api/Web/SiteGroups/RemoveById(12)"), $"Unexpected request: {request.ApiCall.Request}");
+            }
+        }
+
+        [TestMethod]
+        public async Task DeleteSiteGroupByIdRejectsAnInvalidId()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(async () =>
+                {
+                    await context.Web.SiteGroups.DeleteByIdAsync(0);
+                });
+            }
+        }
+
     }
 }

--- a/src/sdk/PnP.Core.Test/Security/UserTests.cs
+++ b/src/sdk/PnP.Core.Test/Security/UserTests.cs
@@ -7,6 +7,7 @@ using PnP.Core.Utilities;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace PnP.Core.Test.Security
@@ -324,5 +325,37 @@ namespace PnP.Core.Test.Security
         }
 
         #endregion
+
+        [TestMethod]
+        public async Task DeleteSiteUserByIdGeneratesTheRemoveCall()
+        {
+            // Offline by design. The delete is added to a batch and the generated request is inspected rather
+            // than executed, which covers the full public path from IWeb.SiteUsers.DeleteByIdBatchAsync down to
+            // the resolved rest url without needing recorded responses.
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                var batch = context.NewBatch();
+
+                await context.Web.SiteUsers.DeleteByIdBatchAsync(batch, 12);
+
+                Assert.AreEqual(1, batch.Requests.Count);
+                var request = batch.Requests.First().Value;
+                Assert.AreEqual(HttpMethod.Delete, request.Method);
+                Assert.IsTrue(request.ApiCall.Request.EndsWith("/_api/Web/GetUserById(12)"), $"Unexpected request: {request.ApiCall.Request}");
+            }
+        }
+
+        [TestMethod]
+        public async Task DeleteSiteUserByIdRejectsAnInvalidId()
+        {
+            using (var context = await TestCommon.Instance.GetContextWithoutInitializationAsync(TestCommon.TestSite))
+            {
+                await Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(async () =>
+                {
+                    await context.Web.SiteUsers.DeleteByIdAsync(0);
+                });
+            }
+        }
+
     }
 }

--- a/src/sdk/PnP.Core/Model/Security/Public/ISharePointGroupCollection.cs
+++ b/src/sdk/PnP.Core/Model/Security/Public/ISharePointGroupCollection.cs
@@ -9,7 +9,7 @@ namespace PnP.Core.Model.Security
     /// Public interface to define a collection of SharePoint groups
     /// </summary>
     [ConcreteType(typeof(SharePointGroupCollection))]
-    public interface ISharePointGroupCollection : IQueryable<ISharePointGroup>, IAsyncEnumerable<ISharePointGroup>, IDataModelCollection<ISharePointGroup>, IDataModelCollectionLoad<ISharePointGroup>, ISupportModules<ISharePointGroupCollection>
+    public interface ISharePointGroupCollection : IQueryable<ISharePointGroup>, IAsyncEnumerable<ISharePointGroup>, IDataModelCollection<ISharePointGroup>, IDataModelCollectionLoad<ISharePointGroup>, IDataModelCollectionDeleteByIntegerId, ISupportModules<ISharePointGroupCollection>
     {
         /// <summary>
         /// Adds a new group

--- a/src/sdk/PnP.Core/Model/Security/Public/ISharePointUserCollection.cs
+++ b/src/sdk/PnP.Core/Model/Security/Public/ISharePointUserCollection.cs
@@ -9,7 +9,7 @@ namespace PnP.Core.Model.Security
     /// Public interface to define a collection of SharePoint users
     /// </summary>
     [ConcreteType(typeof(SharePointUserCollection))]
-    public interface ISharePointUserCollection : IQueryable<ISharePointUser>, IAsyncEnumerable<ISharePointUser>, IDataModelCollection<ISharePointUser>, IDataModelCollectionLoad<ISharePointUser>, ISupportModules<ISharePointUserCollection>
+    public interface ISharePointUserCollection : IQueryable<ISharePointUser>, IAsyncEnumerable<ISharePointUser>, IDataModelCollection<ISharePointUser>, IDataModelCollectionLoad<ISharePointUser>, IDataModelCollectionDeleteByIntegerId, ISupportModules<ISharePointUserCollection>
     {
 
         /// <summary>


### PR DESCRIPTION
Closes #1641

Thanks for the assignment @Adam-it.

## What was missing

Removing a site user or a site group when you only have the id meant fetching the object first, because neither collection interface exposed the delete by id methods. That is the workaround @viceice described in the issue.

## The change

Two lines of production code.

`BaseDataModelCollection<TModel>` already implements `DeleteById`, `DeleteByIdAsync` and the three batch variants, and the [contributor guide](https://pnp.github.io/pnpcore/contributing/readme.html) states a collection may expose them once the collection's model implements `IDataModelDelete`. `ISharePointUser` and `ISharePointGroup` both already do, and both use an `int` key, so `IDataModelCollectionDeleteByIntegerId` is the matching interface:

```csharp
public interface ISharePointUserCollection : ..., IDataModelCollectionDeleteByIntegerId, ISupportModules<ISharePointUserCollection>
public interface ISharePointGroupCollection : ..., IDataModelCollectionDeleteByIntegerId, ISupportModules<ISharePointGroupCollection>
```

No new implementation code, no changes to the model attributes.

## Naming

The issue title asks for `RemoveById`, matching the REST method name. Every other collection in the SDK exposes this as `DeleteById` through the three `IDataModelCollectionDeleteBy*Id` interfaces, so I went with `DeleteById` for consistency. Say the word if you would rather mirror the REST naming here and I will rename, or add `RemoveById` alongside it.

## The generated calls were already correct

I initially suspected a second bug underneath, since `SP.User` sets no `Delete` on its `SharePointType` attributes and `EntityManager` falls back to `Uri`. I checked that against a real tenant before writing any code and **it works correctly**, so nothing needed changing there:

| Case | Endpoint | Result |
|---|---|---|
| user from `web.SiteUsers` | `DELETE _api/Web/GetUserById({Id})` | removed from the site |
| user from `group.Users` | `DELETE _api/Web/sitegroups/getbyid({Parent.Id})/users/getbyid({Id})` | removed from the group only, site user left intact |
| group from `web.SiteGroups` | `DELETE _api/Web/SiteGroups/RemoveById({Id})` | removed |

The group scoped case correctly removes only the membership, which is the right semantics. I corrected my earlier comment on the issue rather than leaving the wrong claim standing.

## Tests

Four offline tests. Two add the delete to a batch and assert the resolved request url and http method instead of executing it, which covers the full public path from `IWeb.SiteUsers` / `IWeb.SiteGroups` down to the generated rest call:

```csharp
var batch = context.NewBatch();
await context.Web.SiteGroups.DeleteByIdBatchAsync(batch, 12);

var request = batch.Requests.First().Value;
Assert.AreEqual(HttpMethod.Delete, request.Method);
Assert.IsTrue(request.ApiCall.Request.EndsWith("/_api/Web/SiteGroups/RemoveById(12)"));
```

I deliberately did not record new mock responses. The existing `.response.json` files come from your test tenant, and recording against mine would put a different tenant's urls and ids into the suite. Asserting the generated request keeps the coverage meaningful while staying offline. Two further tests cover the `ArgumentOutOfRangeException` on an invalid id.

Full offline suite: the 9 failures are all pre existing on `dev` on my machine (timezone, access token, `RepeatedCloneOffLineTest`, `SchedulePagePublish`, and one live call failing on a local TLS quirk). Nothing in the touched area.

## Evidence from a real tenant

Same console app, same site, only the `PnP.Core.dll` differs. The capability check is done on the public interface, since the methods already exist on the concrete collection class and it is the interface surface that changes.

**Before**

![before](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1641/1641-before.png)

**After**

![after](https://raw.githubusercontent.com/svermaak/pnpcore/assets-1641/1641-after.png)

| | Before | After |
|---|---|---|
| `ISharePointUserCollection` exposes delete by id | NO | YES |
| `ISharePointGroupCollection` exposes delete by id | NO | YES |
| Removing a group by id | load `SiteGroups`, find it, `Delete()` | `SiteGroups.DeleteByIdAsync(id)` |
| Removing a site user by id | load `SiteUsers`, find it, `Delete()` | `SiteUsers.DeleteByIdAsync(id)` |

Removal was verified in both runs by re-reading the collection from a fresh context afterwards.
